### PR TITLE
SOC-4729 Remove unused properties in UISpaceSearch class

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/space/UISpaceSearch.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/space/UISpaceSearch.java
@@ -56,16 +56,6 @@ public class UISpaceSearch extends UIForm {
   
   private static final String PERCENTAGE_STR = "%";
   
-  /**
-   * INPUT PATTERN FOR CHECKING.
-   */
-  static final String RIGHT_INPUT_PATTERN = "^[\\p{L}][\\p{L}._\\- \\d]+$";
-  
-  /**
-   * ADD PREFIX TO ENSURE ALWAY RIGHT THE PATTERN FOR CHECKING
-   */
-  static final String PREFIX_ADDED_FOR_CHECK = "PrefixAddedForCheck";
-  
   private final String POPUP_ADD_SPACE = "UIPopupAddSpace";
 
   /** Html attribute title. */


### PR DESCRIPTION
Fix description: remove properties RIGHT_INPUT_PATTERN and PREFIX_ADDED_FOR_CHECK in UISpaceSearch and UIProfileUserSearch classes.