### PR TITLE
SOC-5045: Cannot update space's membership by Id

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesV1.java
@@ -60,7 +60,7 @@ import org.exoplatform.social.service.rest.api.VersionResources;
 @Api(value=VersionResources.VERSION_ONE + "/social/spacesMemberships", description = "Operations membership of space.")
 public class SpaceMembershipRestResourcesV1 implements SpaceMembershipRestResources {
   
-  private static final String SPACE_PREFIX = "/space/";
+  private static final String SPACE_PREFIX = "/spaces/";
   
   private enum MembershipType {
     ALL, PENDING, APPROVED

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesTest.java
@@ -147,7 +147,7 @@ public class SpaceMembershipRestResourcesTest extends AbstractResourceTest {
     space.setVisibility(Space.PRIVATE);
     space.setRegistration(Space.VALIDATION);
     space.setPriority(Space.INTERMEDIATE_PRIORITY);
-    space.setGroupId("/space/space" + number);
+    space.setGroupId("/spaces/space" + number);
     String[] managers = new String[] {creator};
     String[] members = new String[] {creator};
     space.setManagers(managers);


### PR DESCRIPTION
Fix description: This PR fixes also: SOC-5035 & SOC-5044
* Problem: Wrong prefix space name: /space/
* Fix: Replace: /space/ => /spaces/