### PR TITLE
SOC-5310 : Add Api-Access privilege to All rest api

### DIFF
--- a/component/service/src/main/java/org/exoplatform/social/rest/api/RestUtils.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/api/RestUtils.java
@@ -47,6 +47,8 @@ public class RestUtils {
 
   public static final String SUPPORT_TYPE   = "json";
 
+  public static final String API_ACCESS_GROUP    = "/platform/api-access";
+
   public static final String ADMIN_GROUP    = "/platform/administrators";
   
   public static String formatISO8601(Date date) {
@@ -114,6 +116,15 @@ public class RestUtils {
    */
   public static boolean isMemberOfAdminGroup() {
     return ConversationState.getCurrent().getIdentity().isMemberOf(ADMIN_GROUP);
+  }
+
+  /**
+   * Check if the authenticated user is a member of the api access group
+   *
+   * @return
+   */
+  public static boolean isMemberOfAPIAccessGroup() {
+    return ConversationState.getCurrent().getIdentity().isMemberOf(API_ACCESS_GROUP);
   }
   
   /** 

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesV1.java
@@ -137,7 +137,7 @@ public class ActivityRestResourcesV1 implements ActivityRestResources {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     
-    DataEntity as = EntityBuilder.getActivityStream(activity.isComment() ? activityManager.getParentActivity(activity) : activity, currentUser);
+    DataEntity as = EntityBuilder.getAllActivityStream(activity.isComment() ? activityManager.getParentActivity(activity) : activity, currentUser);
     if (as == null && !hasMention(currentUser, activity)) { //current user doesn't have permission to view activity
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
@@ -253,7 +253,7 @@ public class ActivityRestResourcesV1 implements ActivityRestResources {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     
-    if (EntityBuilder.getActivityStream(activity, currentUser) == null && !hasMention(currentUser, activity)) { //current user doesn't have permission to view activity
+    if (EntityBuilder.getAllActivityStream(activity, currentUser) == null && !hasMention(currentUser, activity)) { //current user doesn't have permission to view activity
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     
@@ -344,7 +344,7 @@ public class ActivityRestResourcesV1 implements ActivityRestResources {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     
-    if (EntityBuilder.getActivityStream(activity, currentUser) == null && !hasMention(currentUser, activity)) { //current user doesn't have permission to view activity
+    if (EntityBuilder.getAllActivityStream(activity, currentUser) == null && !hasMention(currentUser, activity)) { //current user doesn't have permission to view activity
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     List<DataEntity> likesEntity = EntityBuilder.buildEntityFromLike(activity, uriInfo.getPath(), expand, offset, limit);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/relationship/RelationshipsRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/relationship/RelationshipsRestResourcesV1.java
@@ -95,7 +95,7 @@ public class RelationshipsRestResourcesV1 implements RelationshipsRestResources 
     
     List<Relationship> relationships = new ArrayList<Relationship>();
     int size = 0;
-    if (identityId != null & RestUtils.isMemberOfAdminGroup()) {
+    if (identityId != null & (RestUtils.isMemberOfAdminGroup() || RestUtils.isMemberOfAPIAccessGroup())) {
       Identity identity = CommonsUtils.getService(IdentityManager.class).getIdentity(identityId, false);
       if (identity == null) {
         throw new WebApplicationException(Response.Status.PRECONDITION_FAILED);

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/space/SpaceRestResourcesV1.java
@@ -113,14 +113,14 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
       spaceFilter.setSpaceNameSearchCondition(q);
     }
     String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
-    if (userACL.getSuperUser().equals(authenticatedUser)) {
+    if (userACL.getSuperUser().equals(authenticatedUser) ||RestUtils.isMemberOfAPIAccessGroup()) {
       listAccess = spaceService.getAllSpacesByFilter(spaceFilter);
     } else {
       listAccess = spaceService.getAccessibleSpacesByFilter(authenticatedUser, spaceFilter);
     }
     List<DataEntity> spaceInfos = new ArrayList<DataEntity>();
     for (Space space : listAccess.load(offset, limit)) {
-      SpaceEntity spaceInfo = EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), expand);
+      SpaceEntity spaceInfo = EntityBuilder.advancedBuildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), expand);
       //
       spaceInfos.add(spaceInfo.getDataEntity()); 
     }
@@ -203,10 +203,10 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     Space space = spaceService.getSpaceById(id);
-    if (space == null || (Space.HIDDEN.equals(space.getVisibility()) && ! spaceService.isMember(space, authenticatedUser) && ! userACL.getSuperUser().equals(authenticatedUser))) {
+    if (space == null || (Space.HIDDEN.equals(space.getVisibility()) && ! spaceService.isMember(space, authenticatedUser) && ! userACL.getSuperUser().equals(authenticatedUser)&& ! RestUtils.isMemberOfAPIAccessGroup())) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
-    return EntityBuilder.getResponse(EntityBuilder.buildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), expand), uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);
+    return EntityBuilder.getResponse(EntityBuilder.advancedBuildEntityFromSpace(space, authenticatedUser, uriInfo.getPath(), expand), uriInfo, RestUtils.getJsonMediaType(), Response.Status.OK);
   }
   
   /**
@@ -309,7 +309,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     //
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     Space space = spaceService.getSpaceById(id);
-    if (space == null || (! spaceService.isMember(space, authenticatedUser) && ! userACL.getSuperUser().equals(authenticatedUser))) {
+    if (space == null || (! spaceService.isMember(space, authenticatedUser) && ! userACL.getSuperUser().equals(authenticatedUser) && ! RestUtils.isMemberOfAPIAccessGroup())) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     
@@ -357,7 +357,7 @@ public class SpaceRestResourcesV1 implements SpaceRestResources {
     //
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
     Space space = spaceService.getSpaceById(id);
-    if (space == null || (! spaceService.isMember(space, authenticatedUser) && ! userACL.getSuperUser().equals(authenticatedUser))) {
+    if (space == null || (! spaceService.isMember(space, authenticatedUser) && ! userACL.getSuperUser().equals(authenticatedUser)) && ! RestUtils.isMemberOfAPIAccessGroup()) {
       throw new WebApplicationException(Response.Status.UNAUTHORIZED);
     }
     

--- a/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
+++ b/component/service/src/main/java/org/exoplatform/social/rest/impl/user/UserRestResourcesV1.java
@@ -327,7 +327,7 @@ public class UserRestResourcesV1 implements UserRestResources {
     }
     //Check permission of authenticated user : he must be an admin or he is the given user
     String authenticatedUser = ConversationState.getCurrent().getIdentity().getUserId();
-    if (!userACL.getSuperUser().equals(authenticatedUser) && !authenticatedUser.equals(id) ) {
+    if (!userACL.getSuperUser().equals(authenticatedUser) && !authenticatedUser.equals(id) && !RestUtils.isMemberOfAPIAccessGroup() ) {
       throw new WebApplicationException(Response.Status.FORBIDDEN);
     }
     
@@ -335,7 +335,7 @@ public class UserRestResourcesV1 implements UserRestResources {
     ListAccess<Space> listAccess = CommonsUtils.getService(SpaceService.class).getMemberSpaces(id);
     
     for (Space space : listAccess.load(offset, limit)) {
-      SpaceEntity spaceInfo = EntityBuilder.buildEntityFromSpace(space, id, uriInfo.getPath(), expand);
+      SpaceEntity spaceInfo = EntityBuilder.advancedBuildEntityFromSpace(space, id, uriInfo.getPath(), expand);
       //
       spaceInfos.add(spaceInfo.getDataEntity()); 
     }
@@ -414,7 +414,7 @@ public class UserRestResourcesV1 implements UserRestResources {
     Identity currentUser = CommonsUtils.getService(IdentityManager.class).getOrCreateIdentity(OrganizationIdentityProvider.NAME, authenticatedUser, true);
     List<DataEntity> activityEntities = new ArrayList<DataEntity>();
     for (ExoSocialActivity activity : activities) {
-      DataEntity as = EntityBuilder.getActivityStream(activity, currentUser);
+      DataEntity as = EntityBuilder.getAllActivityStream(activity, currentUser);
       if (as == null) continue;
       ActivityEntity activityEntity = EntityBuilder.buildEntityFromActivity(activity, uriInfo.getPath(), expand);
       activityEntity.setActivityStream(as);

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/activity/ActivityRestResourcesTest.java
@@ -2,9 +2,11 @@ package org.exoplatform.social.rest.impl.activity;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 import org.exoplatform.social.core.activity.model.ExoSocialActivityImpl;
 import org.exoplatform.social.core.identity.model.Identity;
@@ -35,6 +37,7 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
   private Identity johnIdentity;
   private Identity maryIdentity;
   private Identity demoIdentity;
+  private Identity apiIdentity;
 
   public void setUp() throws Exception {
     super.setUp();
@@ -51,11 +54,13 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     johnIdentity = new Identity("organization", "john");
     maryIdentity = new Identity("organization", "mary");
     demoIdentity = new Identity("organization", "demo");
+    apiIdentity = new Identity("organization", "api");
     
     identityStorage.saveIdentity(rootIdentity);
     identityStorage.saveIdentity(johnIdentity);
     identityStorage.saveIdentity(maryIdentity);
     identityStorage.saveIdentity(demoIdentity);
+    identityStorage.saveIdentity(apiIdentity);
     
     activityRestResourcesV1 = new ActivityRestResourcesV1();
     registry(activityRestResourcesV1);
@@ -74,6 +79,7 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     identityStorage.deleteIdentity(johnIdentity);
     identityStorage.deleteIdentity(maryIdentity);
     identityStorage.deleteIdentity(demoIdentity);
+    identityStorage.deleteIdentity(apiIdentity);
     
     super.tearDown();
     removeResource(activityRestResourcesV1.getClass());
@@ -191,6 +197,16 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     assertEquals(200, response.getStatus());
     collections = (CollectionEntity) response.getEntity();
     assertEquals(5, collections.getEntities().size());
+
+    //api-access
+    HashSet<MembershipEntry> ms = new HashSet<MembershipEntry>();
+    ms.add(new MembershipEntry("/platform/api-access"));
+    startSessionAs("api",ms);
+    response = service("GET", "/" + VersionResources.VERSION_ONE + "/social/activities/" + rootActivity.getId() + "/comments", "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    collections = (CollectionEntity) response.getEntity();
+    assertEquals(5, collections.getEntities().size());
     
     //clean data
     activityManager.deleteActivity(rootActivity);
@@ -234,6 +250,16 @@ public class ActivityRestResourcesTest extends AbstractResourceTest {
     assertNotNull(response);
     assertEquals(200, response.getStatus());
     CollectionEntity collections = (CollectionEntity) response.getEntity();
+    assertEquals(1, collections.getEntities().size());
+
+    //api-access
+    HashSet<MembershipEntry> ms = new HashSet<MembershipEntry>();
+    ms.add(new MembershipEntry("/platform/api-access"));
+    startSessionAs("api",ms);
+    response = service("GET", "/" + VersionResources.VERSION_ONE + "/social/activities/" + rootActivity.getId() + "/likes", "", null, null);
+    assertNotNull(response);
+    assertEquals(200, response.getStatus());
+    collections = (CollectionEntity) response.getEntity();
     assertEquals(1, collections.getEntities().size());
     
     //clean data

--- a/component/service/src/test/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesTest.java
+++ b/component/service/src/test/java/org/exoplatform/social/rest/impl/spacemembership/SpaceMembershipRestResourcesTest.java
@@ -1,12 +1,14 @@
 package org.exoplatform.social.rest.impl.spacemembership;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang.ArrayUtils;
 import org.exoplatform.services.rest.impl.ContainerResponse;
+import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.provider.SpaceIdentityProvider;
 import org.exoplatform.social.core.manager.IdentityManager;

--- a/component/service/src/test/resources/conf/standalone/exo.social.test.portal-configuration.xml
+++ b/component/service/src/test/resources/conf/standalone/exo.social.test.portal-configuration.xml
@@ -102,6 +102,14 @@
                     <field  name="label"><string>Spaces</string></field>
                   </object>
                 </value>
+                <value>
+                  <object type="org.exoplatform.services.organization.OrganizationConfig$Group">
+                    <field  name="name"><string>api-access</string></field>
+                    <field  name="parentId"><string>/platform</string></field>
+                    <field  name="description"><string>tthe /platform/api-access group</string></field>
+                    <field  name="label"><string>api-access</string></field>
+                  </object>
+                </value>
               </collection>
             </field>
 
@@ -116,6 +124,18 @@
                     <field  name="email"><string>root@localhost</string></field>
                     <field  name="groups">
                       <string>manager:/platform/administrators,member:/platform/users</string>
+                    </field>
+                  </object>
+                </value>
+                <value>
+                  <object type="org.exoplatform.services.organization.OrganizationConfig$User">
+                    <field  name="userName"><string>api</string></field>
+                    <field  name="password"><string>gtn</string></field>
+                    <field  name="firstName"><string>Api</string></field>
+                    <field  name="lastName"><string>Api</string></field>
+                    <field  name="email"><string>api@localhost</string></field>
+                    <field  name="groups">
+                      <string>member:/platform/users,member:/platform/api-access</string>
                     </field>
                   </object>
                 </value>


### PR DESCRIPTION
To have a read access to all spaces, you should use the super user.
The goal of this task is to add api-access privileges : A technical user with elevated privileges (read all on all streams)
The rest API implementation must be modified to consider a special role for the caller.
If the the user principal is in group /platform/api-access API calls should return fetch all data of all streams.