### PR TITLE
SOC-5398 : always keep the container for buttons, so that addons can always add buttons

### DIFF
--- a/extension/war/src/main/webapp/groovy/social/webui/connections/UIInvitations.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/connections/UIInvitations.gtmpl
@@ -161,12 +161,12 @@
 	            <%  } %>
 		      </div>
 		
-		      <% if (isEditable) {%>
 		      <div class="connectionBtn clearfix">
+		        <% if (isEditable) {%>
 			      <button class="btn pull-right" onclick="<%=uicomponent.event("Ignore",identity.getId())%>">$ignoreLabel</button>
 			      <button class="btn pull-right btn-primary" onclick="<%=uicomponent.event("Confirm",identity.getId())%>">$confirmLabel</button>    
+		        <% } %>
 		      </div>
-		      <% } %>
         </div>
       </div>
       <% } %> 

--- a/extension/war/src/main/webapp/groovy/social/webui/connections/UIMyConnections.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/connections/UIMyConnections.gtmpl
@@ -148,11 +148,11 @@
 	            <%  } %>
 	          </div>
 	          
-		        <% if (isEditable) {%>
 		        <div class="connectionBtn clearfix">
+		          <% if (isEditable) {%>
 	            <button class="btn pull-right" onclick="$removeConnectionAction">$removeTitle</button>
+		          <% } %>
 	          </div>
-		        <% } %>	         
 	        </div>
         </div>
     <%  } %>

--- a/extension/war/src/main/webapp/groovy/social/webui/connections/UIPendingRelation.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/connections/UIPendingRelation.gtmpl
@@ -142,11 +142,11 @@
 	                <div class="email"><a class="ellipsis" href="mailto:${email}">${email}</a></div>
                 <% } %>
 			      </div>
-		       <% if (isEditable) {%>
 		       	<div class="connectionBtn clearfix">
+		          <% if (isEditable) {%>
 		          <button class="btn pull-right" onclick="<%=uicomponent.event("Ignore",identity.getId())%>">$cancelRequestLabel</button>
+		          <% } %>
 		        </div>
-		      <% } %>
   		    </div>
 		    </div>
       <% } %>


### PR DESCRIPTION
This PR moves div containers related to action buttons on profiles in order to make them also present, so that addons can always adds custom buttons.
This avoids the video call addon to try over and over to add the button and to make server calls.