### PR TITLE
SOC-5507 : removes the HTML sanitization before storing the activity message

### DIFF
--- a/component/common/pom.xml
+++ b/component/common/pom.xml
@@ -102,6 +102,10 @@
       <artifactId>pc-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.exoplatform.commons</groupId>
+      <artifactId>commons-component-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.gatein.portal</groupId>
       <artifactId>exo.portal.component.common</artifactId>
       <exclusions>

--- a/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/SanitizeFilterPlugin.java
+++ b/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/SanitizeFilterPlugin.java
@@ -16,50 +16,35 @@
  */
 package org.exoplatform.social.common.xmlprocessor.filters;
 
-import java.util.LinkedList;
-
-import org.apache.commons.lang.StringEscapeUtils;
+import org.exoplatform.commons.utils.HTMLSanitizer;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
 import org.exoplatform.social.common.xmlprocessor.BaseXMLFilterPlugin;
-import org.exoplatform.social.common.xmlprocessor.model.Node;
 
 
 /**
- * The filter escapes all content of the DOMTree to make sure it cleaned.
+ * The filter escapes all the DOMTree to make sure it cleaned.
  * <b>Note:</b> this filter cannot detect that content escaped or not so make sure that you don't use it twice or
  * using it with escaped content.
  *
  * @author Ly Minh Phuong - http://phuonglm.net
- * @since  1.2.1
  */
-public class DOMContentEscapeFilterPlugin extends BaseXMLFilterPlugin {
+public class SanitizeFilterPlugin extends BaseXMLFilterPlugin {
+
+  private static final Log LOG = ExoLogger.getLogger(SanitizeFilterPlugin.class);
 
   /**
    * {@inheritDoc}
    */
   @Override
   public Object doFilter(Object input) {
-    if (input instanceof Node) {
-      nodeFilter((Node) input);
+    if (input instanceof String) {
+      try {
+        return HTMLSanitizer.sanitize((String) input);
+      } catch (Exception e) {
+        LOG.error("Error while sanitizing input : " + e.getMessage(), e);
+      }
     }
     return input;
   }
-
-  /**
-   * Filter by nodes.
-   *
-   * @param node a node
-   */
-  private void nodeFilter(Node node) {
-    LinkedList<Node> currentChildNode = node.getChildNodes();
-    if (node.getParentNode() != null) {
-      if (!node.getContent().isEmpty()) {
-        node.setContent(StringEscapeUtils.escapeHtml(node.getContent()));
-      }
-    }
-    for (int i = 0; i < currentChildNode.size(); i++) {
-      nodeFilter(currentChildNode.get(i));
-    }
-
-  }
-
 }

--- a/component/common/src/test/java/org/exoplatform/social/common/NoContainerTestSuite.java
+++ b/component/common/src/test/java/org/exoplatform/social/common/NoContainerTestSuite.java
@@ -19,7 +19,7 @@ package org.exoplatform.social.common;
 import org.exoplatform.social.common.jcr.filter.FilterLiteralTest;
 import org.exoplatform.social.common.xmlprocessor.DOMParserTest;
 import org.exoplatform.social.common.xmlprocessor.TokenizerTest;
-import org.exoplatform.social.common.xmlprocessor.filters.DOMContentEscapeFilterPluginTest;
+import org.exoplatform.social.common.xmlprocessor.filters.SanitizeFilterPluginTest;
 import org.exoplatform.social.common.xmlprocessor.filters.DOMLineBreakerFilterPluginTest;
 import org.exoplatform.social.common.xmlprocessor.filters.DOMXMLTagFilterPluginTest;
 import org.exoplatform.social.common.xmlprocessor.filters.LineBreakerFilterPluginTest;
@@ -38,7 +38,7 @@ import org.junit.runners.Suite.SuiteClasses;
   DOMParserTest.class,
   TokenizerTest.class,
   AttributesTest.class,
-  DOMContentEscapeFilterPluginTest.class,
+  SanitizeFilterPluginTest.class,
   DOMLineBreakerFilterPluginTest.class,
   DOMXMLTagFilterPluginTest.class,
   LineBreakerFilterPluginTest.class,

--- a/component/common/src/test/java/org/exoplatform/social/common/xmlprocessor/filters/SanitizeFilterPluginTest.java
+++ b/component/common/src/test/java/org/exoplatform/social/common/xmlprocessor/filters/SanitizeFilterPluginTest.java
@@ -23,29 +23,29 @@ import org.exoplatform.social.common.xmlprocessor.model.Node;
 import junit.framework.TestCase;
 
 /**
- * Unit test for {@link DOMContentEscapeFilterPlugin}.
+ * Unit test for {@link SanitizeFilterPlugin}.
  */
-public class DOMContentEscapeFilterPluginTest extends TestCase {
+public class SanitizeFilterPluginTest extends TestCase {
 
   /**
-   * Tests {@link DOMContentEscapeFilterPlugin#doFilter(Object)}.
+   * Tests {@link SanitizeFilterPlugin#doFilter(Object)}.
    */
-  public void testDOMContentEscape() {
+  public void testContentEscape() {
     assertEquals(
             "",
-            new DOMContentEscapeFilterPlugin().doFilter(
+            new SanitizeFilterPlugin().doFilter(
                     DOMParser.createDOMTree(new Node(), Tokenizer.tokenize("")))
                     .toString());
 
     assertEquals(
             "hello 1\r\nhello 2",
-            new DOMContentEscapeFilterPlugin().doFilter(
+            new SanitizeFilterPlugin().doFilter(
                     DOMParser.createDOMTree(new Node(),
                             Tokenizer.tokenize("hello 1\r\nhello 2"))).toString());
 
     assertEquals(
-            "&lt;b&gt; = hello 1 &amp;&quot;\\ hello 2 &lt;a&gt;",
-            new DOMContentEscapeFilterPlugin().doFilter(
+            "<b> = hello 1 &\"\\ hello 2 <a>",
+            new SanitizeFilterPlugin().doFilter(
                     DOMParser.createDOMTree(new Node(),
                             Tokenizer.tokenize("<b> = hello 1 &\"\\ hello 2 <a>")))
                     .toString());

--- a/component/core/src/main/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessor.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessor.java
@@ -25,7 +25,7 @@ import org.exoplatform.social.common.xmlprocessor.XMLProcessor;
 import org.exoplatform.social.core.BaseActivityProcessorPlugin;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 
-public class OSHtmlSanitizerProcessor extends BaseActivityProcessorPlugin {  
+public class OSHtmlSanitizerProcessor extends BaseActivityProcessorPlugin {
   private XMLProcessor xmlProcessor;
 
   public OSHtmlSanitizerProcessor(InitParams params) {
@@ -38,9 +38,9 @@ public class OSHtmlSanitizerProcessor extends BaseActivityProcessorPlugin {
     }
     activity.setTitle((String) xmlProcessor.process(activity.getTitle()));
     activity.setBody((String) xmlProcessor.process(activity.getBody()));
-    
+
     Map<String, String> templateParams = activity.getTemplateParams();
-    
+
     List<String> templateParamKeys = getTemplateParamKeysToFilter(activity);
     for(String key : templateParamKeys){
       templateParams.put(key, (String) xmlProcessor.process(templateParams.get(key)));

--- a/component/core/src/test/java/org/exoplatform/social/core/application/RelationshipPublisherTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/application/RelationshipPublisherTest.java
@@ -117,7 +117,7 @@ public class RelationshipPublisherTest extends  AbstractCoreTest {
     ExoSocialActivity rootActivity = activityManager.getActivity(rootActivityId);
     List<ExoSocialActivity> rootComments = activityManager.getCommentsWithListAccess(rootActivity).loadAsList(0, 10);
     assertEquals(5, rootComments.size());
-    assertEquals("I'm now connected with 5 user(s)",rootActivity.getTitle());
+    assertEquals("I&#39;m now connected with 5 user(s)",rootActivity.getTitle());
     
     String johnActivityId =  identityStorage.getProfileActivityId(johnIdentity.getProfile(), Profile.AttachedActivityType.RELATIONSHIP);
     String maryActivityId =  identityStorage.getProfileActivityId(maryIdentity.getProfile(), Profile.AttachedActivityType.RELATIONSHIP);
@@ -146,16 +146,16 @@ public class RelationshipPublisherTest extends  AbstractCoreTest {
     ExoSocialActivity rootActivity = activityManager.getActivity(rootActivityId);
     List<ExoSocialActivity> rootComments = activityManager.getCommentsWithListAccess(rootActivity).loadAsList(0, 10);
     assertEquals(1, rootComments.size());
-    assertEquals("I'm now connected with 1 user(s)",rootActivity.getTitle());
-    assertEquals("I'm now connected with Demo gtn",rootComments.get(0).getTitle());
+    assertEquals("I&#39;m now connected with 1 user(s)",rootActivity.getTitle());
+    assertEquals("I&#39;m now connected with Demo gtn",rootComments.get(0).getTitle());
     
     String demoActivityId =  identityStorage.getProfileActivityId(demoIdentity.getProfile(), Profile.AttachedActivityType.RELATIONSHIP);
     assertNotNull(demoActivityId);
     ExoSocialActivity demoActivity = activityManager.getActivity(demoActivityId);
     List<ExoSocialActivity> demoComments = activityManager.getCommentsWithListAccess(demoActivity).loadAsList(0, 10);
     assertEquals(1, demoComments.size());
-    assertEquals("I'm now connected with 1 user(s)",demoActivity.getTitle());
-    assertEquals("I'm now connected with Root Root",demoComments.get(0).getTitle());
+    assertEquals("I&#39;m now connected with 1 user(s)",demoActivity.getTitle());
+    assertEquals("I&#39;m now connected with Root Root",demoComments.get(0).getTitle());
     
     Relationship rootToJohnRelationship = relationshipManager.inviteToConnect(rootIdentity, johnIdentity);
     relationshipManager.confirm(rootIdentity, johnIdentity);
@@ -164,16 +164,16 @@ public class RelationshipPublisherTest extends  AbstractCoreTest {
     rootActivity = activityManager.getActivity(rootActivityId);
     rootComments = activityManager.getCommentsWithListAccess(rootActivity).loadAsList(0, 10);
     assertEquals(2, rootComments.size());
-    assertEquals("I'm now connected with 2 user(s)",rootActivity.getTitle());
-    assertEquals("I'm now connected with John Anthony",rootComments.get(1).getTitle());
+    assertEquals("I&#39;m now connected with 2 user(s)",rootActivity.getTitle());
+    assertEquals("I&#39;m now connected with John Anthony",rootComments.get(1).getTitle());
     
     String johnActivityId =  identityStorage.getProfileActivityId(johnIdentity.getProfile(), Profile.AttachedActivityType.RELATIONSHIP);
     assertNotNull(johnActivityId);
     ExoSocialActivity johnActivity = activityManager.getActivity(johnActivityId);
     List<ExoSocialActivity> johnComments = activityManager.getCommentsWithListAccess(johnActivity).loadAsList(0, 10);
     assertEquals(1, johnComments.size());
-    assertEquals("I'm now connected with 1 user(s)",johnActivity.getTitle());
-    assertEquals("I'm now connected with Root Root",johnComments.get(0).getTitle());
+    assertEquals("I&#39;m now connected with 1 user(s)",johnActivity.getTitle());
+    assertEquals("I&#39;m now connected with Root Root",johnComments.get(0).getTitle());
     
     //remove a connection will re-updated activity's title
     rootToJohnRelationship = relationshipManager.get(rootIdentity, johnIdentity);
@@ -181,10 +181,10 @@ public class RelationshipPublisherTest extends  AbstractCoreTest {
     relationshipPublisher.removed(new RelationshipEvent(Type.REMOVE, relationshipManager, rootToJohnRelationship));
     
     rootActivity = activityManager.getActivity(rootActivityId);
-    assertEquals("I'm now connected with 1 user(s)",rootActivity.getTitle());
+    assertEquals("I&#39;m now connected with 1 user(s)",rootActivity.getTitle());
     
     johnActivity = activityManager.getActivity(johnActivityId);
-    assertEquals("I'm now connected with 0 user(s)",johnActivity.getTitle());
+    assertEquals("I&#39;m now connected with 0 user(s)",johnActivity.getTitle());
     
     activityManager.deleteActivity(johnActivity);
     activityManager.deleteActivity(rootActivity);
@@ -223,15 +223,15 @@ public class RelationshipPublisherTest extends  AbstractCoreTest {
     ExoSocialActivity rootActivity = activityManager.getActivity(rootActivityId);
     List<ExoSocialActivity> rootComments = activityManager.getCommentsWithListAccess(rootActivity).loadAsList(0, 10);
     assertEquals(1, rootComments.size());
-    assertEquals("I'm now connected with 1 user(s)",rootActivity.getTitle());
-    assertEquals("I'm now connected with Demo gtn",rootComments.get(0).getTitle());
+    assertEquals("I&#39;m now connected with 1 user(s)",rootActivity.getTitle());
+    assertEquals("I&#39;m now connected with Demo gtn",rootComments.get(0).getTitle());
     String demoActivityId =  identityStorage.getProfileActivityId(demoIdentity.getProfile(), Profile.AttachedActivityType.RELATIONSHIP);
     assertNotNull(demoActivityId);
     ExoSocialActivity demoActivity = activityManager.getActivity(demoActivityId);
     List<ExoSocialActivity> demoComments = activityManager.getCommentsWithListAccess(demoActivity).loadAsList(0, 10);
     assertEquals(1, demoComments.size());
-    assertEquals("I'm now connected with 1 user(s)",demoActivity.getTitle());
-    assertEquals("I'm now connected with Root Root",demoComments.get(0).getTitle());
+    assertEquals("I&#39;m now connected with 1 user(s)",demoActivity.getTitle());
+    assertEquals("I&#39;m now connected with Root Root",demoComments.get(0).getTitle());
     relationshipManager.delete(rootToDemoRelationship);
     activityManager.deleteActivity(rootActivity);
     activityManager.deleteActivity(demoActivity);

--- a/component/core/src/test/java/org/exoplatform/social/core/application/SpaceActivityPublisherTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/application/SpaceActivityPublisherTest.java
@@ -159,7 +159,7 @@ public class SpaceActivityPublisherTest extends  AbstractCoreTest {
    assertEquals("Name has been updated to: "+space.getDisplayName(), comments.get(1).getTitle());
    
    //Update space's description
-   space.setDescription("social's team");
+   space.setDescription("social&#39;s team");
    space.setField(UpdatedField.DESCRIPTION);
    spaceService.updateSpace(space);
    comments = activityManager.getCommentsWithListAccess(activity).loadAsList(0, 20);
@@ -201,7 +201,7 @@ public class SpaceActivityPublisherTest extends  AbstractCoreTest {
      comments = activityManager.getCommentsWithListAccess(newActivity).loadAsList(0, 20);
      
      assertEquals(2, activityManager.getCommentsWithListAccess(newActivity).getSize());
-     assertEquals("<a href=\"/portal/classic/profile/demo\">Demo gtn</a> has been promoted as space's manager.", comments.get(1).getTitle());
+     assertEquals("<a href=\"/portal/classic/profile/demo\" rel=\"nofollow\">Demo gtn</a> has been promoted as space&#39;s manager.", comments.get(1).getTitle());
      assertEquals(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false).getId(), comments.get(1).getUserId());
      
      //
@@ -210,12 +210,12 @@ public class SpaceActivityPublisherTest extends  AbstractCoreTest {
      comments = activityManager.getCommentsWithListAccess(newActivity).loadAsList(0, 20);
      
      assertEquals(3, activityManager.getCommentsWithListAccess(newActivity).getSize());
-     assertEquals("<a href=\"/portal/classic/profile/demo\">Demo gtn</a> has been revoked as space's manager.", comments.get(2).getTitle());
+     assertEquals("<a href=\"/portal/classic/profile/demo\" rel=\"nofollow\">Demo gtn</a> has been revoked as space&#39;s manager.", comments.get(2).getTitle());
      assertEquals(identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false).getId(), comments.get(2).getUserId());
    }
    
    {// update both name and description
-     assertEquals("social's team", space.getDescription());
+     assertEquals("social&#39;s team", space.getDescription());
      
      String newDescription = "new description";
      space.setDescription(newDescription);
@@ -236,7 +236,7 @@ public class SpaceActivityPublisherTest extends  AbstractCoreTest {
      spaceService.updateSpace(space);
      comments = activityManager.getCommentsWithListAccess(newActivity).loadAsList(0, 20);
      assertEquals(6, comments.size());
-     assertEquals("Description has been updated to: Cet espace est &agrave; chercher des bugs", comments.get(5).getTitle());
+     assertEquals("Description has been updated to: Cet espace est à chercher des bugs", comments.get(5).getTitle());
    }
    
    //clean up

--- a/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/manager/ActivityManagerTest.java
@@ -544,7 +544,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
     
     demoActivity = activityManager.getActivity(demoActivity.getId());
     assertEquals("demoActivity.getLikeIdentityIds().length must return: 1", 1, demoActivity.getLikeIdentityIds().length);
-    assertEquals("&amp;&quot;demo activity", demoActivity.getTitle());
+    assertEquals("&amp;&#34;demo activity", demoActivity.getTitle());
   }
   /**
    * Test {@link ActivityManager#saveLike(ExoSocialActivity, Identity)}
@@ -879,7 +879,7 @@ public class ActivityManagerTest extends AbstractCoreTest {
    */
   public  void testGetCommentWithHtmlContent() throws ActivityStorageException {
     String htmlString = "<span><strong>foo</strong>bar<script>zed</script></span>";
-    String htmlRemovedString = "<span><strong>foo</strong>bar&lt;script&gt;zed&lt;/script&gt;</span>";
+    String htmlRemovedString = "<strong>foo</strong>bar&lt;script&gt;zed&lt;/script&gt;";
     
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     activity.setTitle("blah blah");

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/OSHtmlSanitizerProcessorTest.java
@@ -65,7 +65,7 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     activity.setTitle(sample);
     processor.processActivity(activity);
 
-    assertEquals("text <a href=\"#\">bar</a> zed", activity.getTitle());
+    assertEquals("text <a href=\"#\" rel=\"nofollow\">bar</a> zed", activity.getTitle());
 
     // only with open tag
     sample = "<strong> only open!!!";
@@ -77,7 +77,7 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     sample = "<script href='#' />bar</a>";
     activity.setTitle(sample);
     processor.processActivity(activity);
-    assertEquals("&lt;script href=&quot;#&quot;&gt;&lt;/script&gt;bar&lt;/a&gt;", activity.getTitle());
+    assertEquals("&lt;script href&#61;&#34;#&#34;&gt;&lt;/script&gt;bar&lt;/a&gt;", activity.getTitle());
 
     // forbidden tag
     sample = "<script>foo</script>";
@@ -89,7 +89,7 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     sample = "<span><strong>foo</strong>bar<script>zed</script></span>";
     activity.setTitle(sample);
     processor.processActivity(activity);
-    assertEquals("<span><strong>foo</strong>bar&lt;script&gt;zed&lt;/script&gt;</span>", activity.getTitle());
+    assertEquals("<strong>foo</strong>bar&lt;script&gt;zed&lt;/script&gt;", activity.getTitle());
   }
   
   public void testProcessActivityWithTemplateParam() throws Exception {
@@ -108,7 +108,7 @@ public class OSHtmlSanitizerProcessorTest extends AbstractCoreTest {
     
     templateParams = activity.getTemplateParams();
     assertEquals("a<br />b", templateParams.get("a"));
-    assertEquals("<a href=\"http://exoplatform.com\" target=\"_blank\">exoplatform.com</a>", templateParams.get("b"));
+    assertEquals("<a href=\"http://exoplatform.com\" rel=\"nofollow\">exoplatform.com</a>", templateParams.get("b"));
     assertEquals("exoplatform.com", templateParams.get("d"));
   }
   

--- a/component/core/src/test/resources/conf/standalone/exo.social.component.core.test.configuration.xml
+++ b/component/core/src/test/resources/conf/standalone/exo.social.component.core.test.configuration.xml
@@ -649,6 +649,11 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>DOMContentEscapeFilterPlugin</name>
+      <set-method>addFilterPlugin</set-method>
+      <type>org.exoplatform.social.common.xmlprocessor.filters.SanitizeFilterPlugin</type>
+    </component-plugin>
   </external-component-plugins>
 
   <!--

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/ActivityCommentMailBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/ActivityCommentMailBuilderTest.java
@@ -147,7 +147,7 @@ public class ActivityCommentMailBuilderTest extends AbstractPluginTest {
     ctx.setNotificationInfos(toRoot);
     Writer writer = new StringWriter();
     buildDigest(ctx, writer);
-    assertDigest(writer, "Demo gtn, John Anthony have commented on your activity: my activity's title post today.");
+    assertDigest(writer, "Demo gtn, John Anthony have commented on your activity: my activity&#39;s title post today.");
   }
   
   public void testDigestWithDeletedComment() throws Exception {
@@ -178,6 +178,6 @@ public class ActivityCommentMailBuilderTest extends AbstractPluginTest {
     ctx.setNotificationInfos(toRoot);
     Writer writer = new StringWriter();
     buildDigest(ctx, writer);
-    assertDigest(writer, "Demo gtn has commented on your activity: my activity's title post today.");
+    assertDigest(writer, "Demo gtn has commented on your activity: my activity&#39;s title post today.");
   }
 }

--- a/component/notification/src/test/resources/conf/standalone/exo.social.component.core.test.configuration.xml
+++ b/component/notification/src/test/resources/conf/standalone/exo.social.component.core.test.configuration.xml
@@ -649,6 +649,11 @@
         </value-param>
       </init-params>
     </component-plugin>
+    <component-plugin>
+      <name>DOMContentEscapeFilterPlugin</name>
+      <set-method>addFilterPlugin</set-method>
+      <type>org.exoplatform.social.common.xmlprocessor.filters.SanitizeFilterPlugin</type>
+    </component-plugin>
   </external-component-plugins>
 
   <!--

--- a/component/webui/src/main/java/org/exoplatform/social/webui/activity/BaseUIActivity.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/activity/BaseUIActivity.java
@@ -21,7 +21,6 @@ import java.util.*;
 import org.apache.commons.lang.ArrayUtils;
 
 import org.exoplatform.commons.utils.CommonsUtils;
-import org.exoplatform.commons.utils.HTMLSanitizer;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.social.common.RealtimeListAccess;
@@ -896,7 +895,7 @@ public class BaseUIActivity extends UIForm {
       uiFormComment.reset();
       //--- Processing outcome here aims to avoid escaping '@' symbol while preventing any undesirable side effects due to CSS sanitization.
       //--- The goal is to avoid escape '@' occurrences in microblog application, this enables to keep mention feature working as expected in the specification
-      uiActivity.saveComment(requestContext.getRemoteUser(), HTMLSanitizer.sanitize(message).replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN, HTML_AT_SYMBOL_PATTERN));
+      uiActivity.saveComment(requestContext.getRemoteUser(), message.replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN, HTML_AT_SYMBOL_PATTERN));
       uiActivity.setCommentFormFocused(true);
       requestContext.addUIComponentToUpdateByAjax(uiActivity);
 

--- a/component/webui/src/main/java/org/exoplatform/social/webui/composer/UIComposer.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/composer/UIComposer.java
@@ -201,7 +201,7 @@ public class UIComposer extends UIForm {
       UIFormTextAreaInput textAreaInput = uiComposer.getUIFormTextAreaInput(COMPOSER_TEXT_AREA_INPUT);
       //--- Processing outcome here aims to avoid escaping '@' symbol while preventing any undesirable side effects due to CSS sanitization.
       //--- The goal is to avoid escape '@' occurrences in microblog application, this enables to keep mention feature working as expected in the specification
-      String message = HTMLSanitizer.sanitize(textAreaInput.getValue()).replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN,HTML_AT_SYMBOL_PATTERN);
+      String message = textAreaInput.getValue().replaceAll(HTML_AT_SYMBOL_ESCAPED_PATTERN,HTML_AT_SYMBOL_PATTERN);
       textAreaInput.setValue("");
       //
       message = (message == null || 

--- a/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
+++ b/extension/war/src/main/webapp/WEB-INF/conf/social-extension/social/component-plugins-configuration.xml
@@ -226,7 +226,12 @@
           <value>-1</value>
         </value-param>
       </init-params>
-    </component-plugin>    
+    </component-plugin>
+    <component-plugin>
+      <name>DOMContentEscapeFilterPlugin</name>
+      <set-method>addFilterPlugin</set-method>
+      <type>org.exoplatform.social.common.xmlprocessor.filters.SanitizeFilterPlugin</type>
+    </component-plugin>
   </external-component-plugins>
 
   <external-component-plugins>


### PR DESCRIPTION
I removed the sanitization before storing the message and added it as an activity processor(OSHtmlSanitizerProcessor) to make sure it is only done once.
I changed the DOMContentEscapeFilterPlugin processor (it was not used) to make it use the HTMLSanitizer service (and also renamed it to SanitizeFilterPlugin) and I added this processor in the list of activity processors.