### PR TITLE
SOC-5514 Space activities are lost after migration when the JCR space identity node has a name not equal to remoteId

### DIFF
--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/storage/RDBMSSpaceStorageImpl.java
@@ -444,8 +444,7 @@ public class RDBMSSpaceStorageImpl extends SpaceStorageImpl implements SpaceStor
         renameIdentity(identitySpace);
       }
 
-      //
-      LOG.debug(String.format("Space %s (%s) saved", space.getPrettyName(), space.getId()));
+      LOG.debug("Space id={} name={} saved", space.getId(), space.getPrettyName());
 
     } catch (NodeNotFoundException e) {
       throw new SpaceStorageException(SpaceStorageException.Type.FAILED_TO_RENAME_SPACE, e.getMessage(), e);
@@ -475,7 +474,7 @@ public class RDBMSSpaceStorageImpl extends SpaceStorageImpl implements SpaceStor
       }
     }
 
-    LOG.debug("Space {} ({}) saved", space.getPrettyName(), space.getId());
+    LOG.debug("Space id={} name={} saved", space.getId(), space.getPrettyName());
   }
 
   @Override

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/IdentityDAOImpl.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/storage/dao/jpa/IdentityDAOImpl.java
@@ -54,7 +54,7 @@ public class IdentityDAOImpl extends GenericDAOJPAImpl<IdentityEntity, Long> imp
   public IdentityEntity create(IdentityEntity entity) {
     IdentityEntity exists = findByProviderAndRemoteId(entity.getProviderId(), entity.getRemoteId());
     if (exists != null) {
-      throw new EntityExistsException("Identity is existed with ProviderID=" + entity.getProviderId() + " and RemoteId=" + entity.getRemoteId());
+      throw new EntityExistsException("Identity already exists provider_id=" + entity.getProviderId() + " remote_id=" + entity.getRemoteId());
     }
     return super.create(entity);
   }

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/AbstractMigrationService.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/AbstractMigrationService.java
@@ -101,7 +101,7 @@ public abstract class AbstractMigrationService<T>  extends AbstractStorage {
       //
       afterMigration();
     } catch (Exception e) {
-      LOG.error("Failed to run migration data from JCR to Mysql.", e);
+      LOG.error("Failed to run data migration from JCR to RDBMS.", e);
     } finally {
       RequestLifeCycle.end();
     }
@@ -300,7 +300,7 @@ public abstract class AbstractMigrationService<T>  extends AbstractStorage {
     EntityManager em = entityManagerService.getEntityManager();
     if (!em.getTransaction().isActive()) {
       em.getTransaction().begin();
-      LOG.debug("started new transaction");
+      LOG.debug("new transaction started");
       return true;
     }
     return false;

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/ActivityMigrationService.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/ActivityMigrationService.java
@@ -39,6 +39,7 @@ import org.exoplatform.services.jcr.impl.core.NodeImpl;
 import org.exoplatform.social.core.jpa.storage.RDBMSActivityStorageImpl;
 import org.exoplatform.social.core.jpa.storage.RDBMSIdentityStorageImpl;
 import org.exoplatform.social.core.jpa.storage.dao.ActivityDAO;
+import org.exoplatform.social.core.jpa.updater.utils.IdentityUtil;
 import org.exoplatform.social.core.jpa.updater.utils.MigrationCounter;
 import org.exoplatform.social.core.jpa.updater.utils.StringUtil;
 import org.exoplatform.social.core.activity.model.ExoSocialActivity;
@@ -745,7 +746,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     try {
       IdentityEntity entity = _findById(IdentityEntity.class, oldId);
       if (entity != null) {
-        Identity id = identityJPAStorage.findIdentity(entity.getProviderId(), entity.getRemoteId());
+        Identity id = identityJPAStorage.findIdentity(entity.getProviderId(), IdentityUtil.getIdentityName(entity.getName()));
         if (id != null) {
           return id.getId();
         }

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/ActivityMigrationService.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/ActivityMigrationService.java
@@ -95,7 +95,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
   }
 
   @Managed
-  @ManagedDescription("Manual to start run miguration data of activities from JCR to RDBMS.")
+  @ManagedDescription("Start the migration of JCR activities to RDBMS.")
   public void doMigration() throws Exception {
     RequestLifeCycle.end();
 
@@ -107,7 +107,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
   }
 
   private long migrateUserActivities() throws Exception {
-    LOG.info("| \\ Start:: migrate activity of users -------------");
+    LOG.info("| \\ Start:: user activities migration -------------");
 
     long totalUsers = getNumberUserIdentities();
 
@@ -142,16 +142,16 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
             counter.newBatchAndWatch();
             counter.getAndIncrementTotal();
 
-            LOG.info(String.format("|  \\ START::user number: %s/%s (%s user)", counter.getTotal(), totalUsers, owner.getRemoteId()));
+            LOG.info("|  \\ START::User activities number: {}/{} remote_id={}", counter.getTotal(), totalUsers, owner.getRemoteId());
             IdentityEntity identityEntity = _findById(IdentityEntity.class, owner.getId());
             try {
               migrationByIdentity(null, identityEntity);
             } catch (Exception ex) {
               numberUserFailed++;
               identitiesMigrateFailed.add(node.getName());
-              LOG.error(String.format("Failed migrate user %s", owner.getRemoteId()), ex);
+              LOG.error("Failed to migrate user remote_id=" + owner.getRemoteId(), ex);
             }
-            LOG.info(String.format("|  / END:: migrate activity of user %s consumed %s(ms) -------------", owner.getRemoteId(), counter.endBatchWatch()));
+            LOG.info("|  / END::User Activities remote_id={} duration_ms={} -------------", owner.getRemoteId(), counter.endBatchWatch());
 
             if (counter.isPersistPoint()) {
               RequestLifeCycle.end();
@@ -169,15 +169,15 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     }
 
     if (numberUserFailed > 0) {
-      LOG.error(String.format("|   Failed in migrate activities of %s user(s)", numberUserFailed));
+      LOG.error("|   Failed to migrate activities of {} user(s)", numberUserFailed);
     }
-    LOG.info(String.format("| / END:: %s user(s) consumed %s(ms) -------------", counter.getTotal(), counter.endTotalWatch()));
+    LOG.info("| / END:: user activities migration {} user(s) duration_ms={} -------------", counter.getTotal(), counter.endTotalWatch());
 
     return numberUserFailed;
   }
 
   private long migrateSpaceActivities() throws Exception {
-    LOG.info("Start to migration space activities from JCR to RDBMS");
+    LOG.info("Starting to migrate space activities from JCR to RDBMS");
     long t = System.currentTimeMillis();
     long totalSpaces = getNumberSpaceIdentities();
 
@@ -210,16 +210,15 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
             long t1 = System.currentTimeMillis();
             //
             IdentityEntity spaceEntity = _findById(IdentityEntity.class, node.getUUID());
-            LOG.info(String.format("|  \\ START::space number: %s/%s (%s space)", offset, totalSpaces, owner.getRemoteId()));
+            LOG.info("|  \\ START::space number: {}/{} remote_id={} uuid={}", offset, totalSpaces, owner.getRemoteId(), owner.getId());
             try {
               migrationByIdentity(null, spaceEntity);
             } catch (Exception ex) {
               numberSpaceFailed++;
               identitiesMigrateFailed.add(node.getName());
-              LOG.error(String.format("Failed migrate space %s", owner.getRemoteId()), ex);
+              LOG.error("Failed migrate space remote_id=" + owner.getRemoteId(), ex);
             }
-            LOG.info(String.format("|  / END:: migrate activity of space %s consumed %s(ms) -------------", owner.getRemoteId(), (System.currentTimeMillis() - t1)));
-
+            LOG.info("|  / END:: migrate activity of space remote_id={} duration_ms={} -------------", owner.getRemoteId(), (System.currentTimeMillis() - t1));
           }
         }
 
@@ -231,16 +230,16 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     }
 
     if (numberSpaceFailed > 0) {
-      LOG.info(" Failed migration for " + numberSpaceFailed + " space(s)");
+      LOG.info(" Failed migration of " + numberSpaceFailed + " space(s)");
     }
 
-    LOG.info(String.format("Done to migration %s space activities from JCR to RDBMS on %s(ms)", offset, (System.currentTimeMillis() - t)));
+    LOG.info("Done to migrate {} space activities from JCR to RDBMS duration_ms={}", offset, (System.currentTimeMillis() - t));
     return numberSpaceFailed;
   }
 
   @Override
   @Managed
-  @ManagedDescription("Manual to stop run miguration data of activities from JCR to RDBMS.")
+  @ManagedDescription("To stop running activities migration from JCR to RDBMS.")
   public void stop() {
     super.stop();
   }
@@ -249,7 +248,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     MigrationContext.setActivityDone(false);
     identitiesMigrateFailed = new HashSet<>();
 
-    LOG.info("Stating to migration activities from JCR to RDBMS........");
+    LOG.info("Starting the migration of activities from JCR to RDBMS........");
   }
 
   private void migrationByIdentity(String userName, IdentityEntity identityEntity) throws Exception {
@@ -265,7 +264,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
       try {
         identityEntity = _findById(IdentityEntity.class, poster.getId());
       } catch (Exception e) {
-        LOG.warn("The user " + userName + " has not identity. Do not migration for this user.");
+        LOG.warn("The user name={} can't be migrated because he has no identity.", userName);
         return;
       }
     }
@@ -286,7 +285,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     Identity jpaIdentity = identityJPAStorage.findIdentity(identityEntity.getProviderId(), identityEntity.getRemoteId());
 
     String type = (OrganizationIdentityProvider.NAME.equals(providerId)) ? "user" : "space";
-    LOG.info(String.format("    Migration activities for %s: %s", type, identityEntity.getRemoteId()));
+    LOG.info("    Migrate activities for {} remote_id={}", type, identityEntity.getRemoteId());
     //
     ActivityListEntity activityListEntity = identityEntity.getActivityList();
     ActivityIterator activityIterator = new ActivityIterator(activityListEntity);
@@ -301,7 +300,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         ActivityEntity activityEntity = getSession().findById(ActivityEntity.class, activityId);
         ActivityUpdaterEntity updater = _getMixin(activityEntity, ActivityUpdaterEntity.class, false);
         if (updater != null) {
-          LOG.info("Activity with ID=" + activityId + " was migrated before");
+          LOG.info("Activity id={} was migrated before", activityId);
           continue;
         }
 
@@ -315,7 +314,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
             String value = entry.getValue();
 
             if (value.length() >= 1024) {
-              LOG.info("===================== activity id " + activity.getId() + " new value length = " +  value.length());
+              LOG.info("===================== activity id={} new value length={}", activity.getId(), value.length());
               params.put(entry.getKey(), "");
             }
 
@@ -362,7 +361,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
                   String value = entry.getValue();
 
                   if (value.length() >= 1024) {
-                    LOG.info("===================== comment id " + oldCommentId + " new value length = " + value.length());
+                    LOG.info("===================== comment id={} new value length={}", oldCommentId, value.length());
                     commentParams.put(entry.getKey(), "");
                   }
 
@@ -398,22 +397,22 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         getSession().save();
 
       } catch (Exception e) {
-        LOG.error("Failed to migrate activity id : " + activityId, e);
+        LOG.error("Failed to migrate activity id=" + activityId, e);
         numberActivitiesFailed++;
       } finally {
         try {
           endTx(begunTx);
         } catch (Exception ex) {
-          LOG.error("Failed to migrate activity id : " + activityId);
+          LOG.error("Failed to migrate activity id=" + activityId);
           numberActivitiesFailed++;
         }
       }
     }
 
-    LOG.info(String.format("    Done migration %s activitie(s) for %s consumed %s(ms) ", count, providerId + "/" +remoteId, System.currentTimeMillis() - t));
+    LOG.info("    Done migration of {} activitie(s) for provider_id={} remote_id={} duration_ms={}", count, providerId, remoteId, System.currentTimeMillis() - t);
     if (numberActivitiesFailed > 0) {
-      LOG.error(String.format("    Failed migration for %s activitie(s)", numberActivitiesFailed));
-      throw new Exception("Migration is failed for " + numberActivitiesFailed + " activities of identity " + providerId + "/" + remoteId);
+      LOG.error("    Failed to migrate {} activitie(s)", numberActivitiesFailed);
+      throw new Exception("Migration is failing for " + numberActivitiesFailed + " activities for identity provider_id=" + providerId + " remote_id=" + remoteId);
     } else if (!forceStop){
       try {
         identityEntity.setProperty(MigrationContext.KEY_MIGRATE_ACTIVITIES, MigrationContext.TRUE_STRING);
@@ -438,18 +437,18 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
       MigrationContext.setActivityDone(true);
     }
 
-    LOG.info("Done to migration activities from JCR to RDBMS");
+    LOG.info("Migration of activities from JCR to RDBMS done");
   }
 
   public void doRemove() throws Exception {
-    LOG.info("Start remove activities from JCR to RDBMS");
+    LOG.info("Starting to remove activities from JCR");
     try {
       RequestLifeCycle.begin(PortalContainer.getInstance());
       removeActivity();
     } finally {
       RequestLifeCycle.end();
     }
-    LOG.info("Done to removed activities from JCR");
+    LOG.info("Done to remove activities from JCR");
   }
 
   private void removeActivity() throws Exception {
@@ -464,7 +463,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     Node node = null;
     boolean isDone = false;
     try {
-      LOG.info("| \\ START::cleanup User Activity ---------------------------------");
+      LOG.info("| \\ START::cleanup User Activities ---------------------------------");
       NodeIterator it = getIdentityNodes(offset, LIMIT_REMOVED_THRESHOLD);
       while (it != null && it.hasNext()) {
         node = (Node) it.next();
@@ -475,12 +474,12 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
           continue;
         }
         offset++;
-        LOG.info(String.format("|  \\ START::cleanup user number: %s/%s (%s user)", offset, totalUsers, node.getName()));
+        LOG.info("|  \\ START::cleanup user number: {}/{} name={}", offset, totalUsers, name);
         isDone = cleanupActivity(node);
         if (!isDone) {
           identitiesCleanupFailed.add(name);
         }
-        LOG.info(String.format("|  / END::cleanup (%s user)", node.getName()));
+        LOG.info("|  / END::cleanup user name={}", name);
         //
         if (offset % LIMIT_REMOVED_THRESHOLD == 0 || isDone == false) {
           RequestLifeCycle.end();
@@ -489,11 +488,11 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         }
       }
     } catch (Exception e) {
-      LOG.error("Failed to cleanup for Activity Reference.", e);
+      LOG.error("Failed to cleanup user activities.", e);
     } finally {
       RequestLifeCycle.end();
       RequestLifeCycle.begin(PortalContainer.getInstance());
-      LOG.info(String.format("| / END::cleanup Activity for (%s) user consumed %s(ms) -------------", offset, System.currentTimeMillis() - t));
+      LOG.info("| / END::cleanup User Activities for {} users duration_ms={} -------------", offset, System.currentTimeMillis() - t);
     }
     
     //cleanup activity
@@ -501,7 +500,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
     node = null;
     offset = 0;
     try {
-      LOG.info("| \\ START::cleanup Space Activity ---------------------------------");
+      LOG.info("| \\ START::cleanup Space activities ---------------------------------");
       NodeIterator it = getSpaceIdentityNodes(offset, LIMIT_REMOVED_THRESHOLD);
       while (it != null && it.hasNext()) {
         node = (Node) it.next();
@@ -513,13 +512,13 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
           continue;
         }
 
-        LOG.info(String.format("|  \\ START::cleanup space number: %s/%s (%s space)", offset, totalSpaces, node.getName()));
+        LOG.info("|  \\ START::cleanup space number: {}/{} name={}", offset, totalSpaces, name);
         isDone = cleanupActivity(node);
         if (!isDone) {
           identitiesCleanupFailed.add(name);
         }
         offset++;
-        LOG.info(String.format("|  / END::cleanup (%s space)", node.getName()));
+        LOG.info("|  / END::cleanup space name={}", name);
         //
         if (offset % LIMIT_REMOVED_THRESHOLD == 0 || isDone == false) {
           RequestLifeCycle.end();
@@ -528,12 +527,12 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         }
       }
     } catch (Exception e) {
-      LOG.error("Failed to cleanup for user Activities.", e);
+      LOG.error("Failed to cleanup space activities.", e);
     } finally {
       MigrationContext.setIdentitiesCleanupActivityFailed(identitiesCleanupFailed);
       RequestLifeCycle.end();
       RequestLifeCycle.begin(PortalContainer.getInstance());
-      LOG.info(String.format("| / END::cleanup Activity for (%s) space consumed %s(ms) -------------", offset, System.currentTimeMillis() - t));
+      LOG.info("| / END::cleanup Activities for {} spaces duration_ms={} -------------", offset, System.currentTimeMillis() - t);
     }
 
   }
@@ -565,7 +564,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
       }
       getSession().save();
     } catch (Exception e) {
-      LOG.error("Failed to cleanup sub node for Activity Reference, activity id =" + nodeId + " path=" + nodePath, e);
+      LOG.error("Failed to cleanup sub node for Activity Reference, activity id=" + nodeId + " path=" + nodePath, e);
       try {
         getSession().getJCRSession().refresh(false);
       } catch (RepositoryException ex) {
@@ -573,7 +572,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
       }
       return false;
     } finally {
-      LOG.info(String.format("|     - Done cleanup: %s ref(s) of (%s) consumed time %s(ms) ", offset, userName, System.currentTimeMillis() - totalTime));
+      LOG.info("|     - Done cleanup: {} ref(s) of user name={} duration_ms={}", offset, userName, System.currentTimeMillis() - totalTime);
     }
     return true;
   }
@@ -601,7 +600,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         return false;
       }
 
-
+      LOG.info("|   | Searching activities to clean for identity name={}", identityName);
       StringBuffer sb = new StringBuffer().append("SELECT * FROM soc:activity WHERE ");
       try {
         String nodeStreamsPath = XPathUtils.escapeIllegalSQLName(identityNode.getNode("soc:activities").getPath());
@@ -615,7 +614,7 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
         long t = System.currentTimeMillis();
         long offset = 0;
 
-        LOG.info(String.format("|   \\ START::cleanup: %d (Activity) for %s identity", size, identityName));
+        LOG.info("|   \\ START::cleanup Activities {} activities for identity name={}", size, identityName);
         try {
           NodeIterator it = nodes(sb.toString(), failed, LIMIT_ACTIVITY_SAVE_THRESHOLD);
           while(it != null && it.hasNext()) {
@@ -629,14 +628,14 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
               }
               //activityJCRStorage.deleteActivity(n.getUUID());
             } catch (Exception ex) {
-              LOG.error("Failed to cleanup activity ID: " + n.getUUID() + " path: " + n.getPath(), ex);
+              LOG.error("Failed clean activity id=" + n.getUUID() + " path=" + n.getPath(), ex);
               failed++;
             }
 
             if (offset % LIMIT_ACTIVITY_SAVE_THRESHOLD == 0) {
               try {
                 getSession().save();
-                LOG.info(String.format("|     - Persist deleted: %s activity consumed time %s(ms) ", LIMIT_ACTIVITY_SAVE_THRESHOLD, System.currentTimeMillis() - t));
+                LOG.info("|     - Persist {} deleted activities duration_ms={}", LIMIT_ACTIVITY_SAVE_THRESHOLD, System.currentTimeMillis() - t);
               } catch (Exception ex) {
                 LOG.error("Failed, can not persist deleted activities", ex);
                 getSession().getJCRSession().refresh(false);
@@ -650,17 +649,17 @@ public class ActivityMigrationService extends AbstractMigrationService<ExoSocial
 
           getSession().save();
           if (offset % LIMIT_ACTIVITY_SAVE_THRESHOLD != 0) {
-            LOG.info(String.format("|     - Persist deleted: %s activity consumed time %s(ms) ", offset % LIMIT_ACTIVITY_SAVE_THRESHOLD, System.currentTimeMillis() - t));
+            LOG.info("|     - Persist {} deleted activities duration_ms={}", offset % LIMIT_ACTIVITY_SAVE_THRESHOLD, System.currentTimeMillis() - t);
           }
         } finally {
-          LOG.info(String.format("|   / END::cleanup: %d (Activity) for %s identity consumed time %s(ms) ", size, identityName, System.currentTimeMillis() - totalTime));
+          LOG.info("|   / END::cleanup Activities {} activities for identity name={} duration_ms={} ", size, identityName, System.currentTimeMillis() - totalTime);
         }
       } else {
-        LOG.info("There is not any activity for identity: " + identityName);
+        LOG.info("There is no activities to clean for identity name={}", identityName);
       }
 
     } catch (Exception e) {
-      LOG.error("Failed to cleanup activities for identity: " + identityName, e);
+      LOG.error("Failed to clean activities for identity name=" + identityName, e);
       try {
         getSession().getJCRSession().refresh(false);
       } catch (RepositoryException ex) {

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/IdentityMigrationService.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/IdentityMigrationService.java
@@ -305,15 +305,17 @@ public class IdentityMigrationService extends AbstractMigrationService<Identity>
 
   private Identity migrateIdentity(Node node, String jcrId) throws Exception {
     String providerId = node.getProperty("soc:providerId").getString();
-    String remoteId = node.getProperty("soc:remoteId").getString();
+    // The node name is the identity id.
+    // Node name is soc:<name>, only the <name> is relevant
+    String name = IdentityUtil.getIdentityName(node.getName());
 
-    Identity identity = identityStorage.findIdentity(providerId, remoteId);
+    Identity identity = identityStorage.findIdentity(providerId, name);
     if (identity != null) {
       LOG.info("Identity with providerId = " + identity.getProviderId() + " and remoteId=" + identity.getRemoteId() + " has already been migrated.");
       return identity;
     }
 
-    identity = new Identity(providerId, remoteId);
+    identity = new Identity(providerId, name);
     identity.setDeleted(node.getProperty("soc:isDeleted").getBoolean());
 
     if (node.isNodeType("soc:isDisabled")) {

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/RDBMSMigrationManager.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/RDBMSMigrationManager.java
@@ -317,7 +317,7 @@ public class RDBMSMigrationManager implements Startable {
                     updateSettingValue(MigrationContext.SOC_RDBMS_MIGRATION_STATUS_KEY, Boolean.TRUE);
                     MigrationContext.setDone(true);
                   } else {
-                    LOG.warn("Social workspace is not removeable, so it is not removed.");
+                    LOG.warn("Social workspace can't be removed");
                   }
 
                 } catch (RepositoryException ex) {
@@ -346,66 +346,65 @@ public class RDBMSMigrationManager implements Startable {
             }
           }
 
-          LOG.info(String.format("Migration job has done, total time is %s (ms)", (System.currentTimeMillis() - startTime)));
-          LOG.info(String.format("Migration space in %s (ms)", timeToMigrateSpaces));
-          LOG.info(String.format("- Number space failed: %s", MigrationContext.getSpaceMigrateFailed().size()));
+          LOG.info("Migration job done, total time is duration_ms={}", (System.currentTimeMillis() - startTime));
+          LOG.info("Migration - Spaces in duration_ms={}", timeToMigrateSpaces);
+          LOG.info("- Number of spaces failed: {}", MigrationContext.getSpaceMigrateFailed().size());
           if (!MigrationContext.getSpaceMigrateFailed().isEmpty()) {
-            LOG.warn("- space failed: " + MigrationContext.getSpaceMigrateFailed());
+            LOG.warn("- spaces failed: " + MigrationContext.getSpaceMigrateFailed());
           }
 
-          LOG.info(String.format("Migration identities in %s (ms)", timeToMigrateIdentities));
-          LOG.info(String.format("- Number identities failed: %s", MigrationContext.getIdentitiesMigrateFailed().size()));
+          LOG.info("Migration - Identities duration_ms={}", timeToMigrateIdentities);
+          LOG.info("- Number of identity failed: {}", MigrationContext.getIdentitiesMigrateFailed().size());
           if (!MigrationContext.getIdentitiesMigrateFailed().isEmpty()) {
             LOG.warn("- identities failed: " + MigrationContext.getIdentitiesMigrateFailed());
           }
 
           if (!MigrationContext.getIdentitiesMigrateFailed().isEmpty()) {
-            LOG.info("We could not continue migration job because the identities migration was failed");
+            LOG.info("We could not continue migration job because the identities migration failed");
           } else {
-            LOG.info(String.format("Migration relationships in %s (ms)", timeToMigrateConnections));
-            LOG.info(String.format("- migrate failed for %s user(s)", MigrationContext.getIdentitiesMigrateConnectionFailed().size()));
+            LOG.info("Migration - Relationships duration_ms={}", timeToMigrateConnections);
+            LOG.info("- migration failed for {} user(s)", MigrationContext.getIdentitiesMigrateConnectionFailed().size());
             if (!MigrationContext.getIdentitiesMigrateConnectionFailed().isEmpty()) {
               LOG.warn("- identities failed: " + MigrationContext.getIdentitiesMigrateConnectionFailed());
             }
 
-            LOG.info(String.format("Migration activities in %s (ms)", timeToMigrateActivities));
-            LOG.info(String.format("- migrate failed for %s user(s)", MigrationContext.getIdentitiesMigrateActivityFailed().size()));
+            LOG.info("Migration - Activities duration_ms={}", timeToMigrateActivities);
+            LOG.info("- migration failed for {} user(s)", MigrationContext.getIdentitiesMigrateActivityFailed().size());
             if (!MigrationContext.getIdentitiesMigrateActivityFailed().isEmpty()) {
               LOG.warn("- identities failed: " + MigrationContext.getIdentitiesMigrateActivityFailed());
             }
 
             // Cleanup
-            LOG.info(String.format("Cleanup relationship in %s (ms)", timeToCleanupConnections));
-            LOG.info(String.format("- cleanup connection failed for %s user(s)", MigrationContext.getIdentitiesCleanupConnectionFailed().size()));
+            LOG.info("Cleanup - Relationships duration_ms={}", timeToCleanupConnections);
+            LOG.info("- connections cleanup failed for {} user(s)", MigrationContext.getIdentitiesCleanupConnectionFailed().size());
             if (!MigrationContext.getIdentitiesCleanupConnectionFailed().isEmpty()) {
               LOG.warn("- identities cleanup failed: " + MigrationContext.getIdentitiesCleanupConnectionFailed());
             }
 
-            LOG.info(String.format("Cleanup activities in %s (ms)", timeToCleanupActivities));
-            LOG.info(String.format("- cleanup activities failed for %s identity(s)", MigrationContext.getIdentitiesCleanupActivityFailed().size()));
+            LOG.info("Cleanup - Activities duration_ms={}", timeToCleanupActivities);
+            LOG.info("- activities cleanup failed for {} identity(s)", MigrationContext.getIdentitiesCleanupActivityFailed().size());
             if (!MigrationContext.getIdentitiesCleanupActivityFailed().isEmpty()) {
               LOG.warn("- identities cleanup failed: " + MigrationContext.getIdentitiesCleanupActivityFailed());
             }
 
-            LOG.info(String.format("Cleanup identities in %s (ms)", timeToCleanupIdentities));
-            LOG.info(String.format("- cleanup failed for %s identity(s)", MigrationContext.getIdentitiesCleanupFailed().size()));
+            LOG.info("Cleanup - Identities duration_ms={}", timeToCleanupIdentities);
+            LOG.info("- cleanup failed for {} identity(s)", MigrationContext.getIdentitiesCleanupFailed().size());
             if (!MigrationContext.getIdentitiesCleanupFailed().isEmpty()) {
               LOG.warn("- identities cleanup failed: " + MigrationContext.getIdentitiesCleanupFailed());
             }
 
-            LOG.info(String.format("Cleanup spaces in %s (ms)", timeToCleanupSpaces));
-            LOG.info(String.format("- cleanup failed for %s space(s)", MigrationContext.getSpaceCleanupFailed().size()));
+            LOG.info("Cleanup - Spaces in duration_ms={}", timeToCleanupSpaces);
+            LOG.info("- cleanup failed for {} space(s)", MigrationContext.getSpaceCleanupFailed().size());
             if (!MigrationContext.getSpaceCleanupFailed().isEmpty()) {
               LOG.warn("- space cleanup failed: " + MigrationContext.getSpaceCleanupFailed());
             }
           }
 
-
-
           migrater.countDown();
         }
       }
     };
+
     this.migrationThread = new Thread(migrateTask);
     this.migrationThread.setPriority(Thread.NORM_PRIORITY);
     this.migrationThread.setName("SOC-MIGRATION-RDBMS");
@@ -514,6 +513,5 @@ public class RDBMSMigrationManager implements Startable {
   public CountDownLatch getMigrater() {
     return migrater;
   }
-  
-  
+
 }

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/listener/RelationshipActivityUpdaterListener.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/listener/RelationshipActivityUpdaterListener.java
@@ -47,7 +47,7 @@ public class RelationshipActivityUpdaterListener extends Listener<ExoSocialActiv
     if (RELATIONSHIP_ACTIVITY_TYPE.equals(activity.getType())) {
       Identity identity = identityStorage.findIdentity(OrganizationIdentityProvider.NAME, activity.getStreamOwner());
       identityStorage.updateProfileActivityId(identity, newActivityId, Profile.AttachedActivityType.RELATIONSHIP);
-      LOG.info(String.format("Migration the relationship activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), newActivityId));
+      LOG.info("Migrate the relationship activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), newActivityId);
     }
     
   }

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/listener/SpaceActivityUpdaterListener.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/listener/SpaceActivityUpdaterListener.java
@@ -47,7 +47,7 @@ public class SpaceActivityUpdaterListener extends Listener<ExoSocialActivity, St
     if (SPACE_ACTIVITY_TYPE.equals(activity.getType())) {
       Identity spaceIdentity = identityStorage.findIdentity(SpaceIdentityProvider.NAME, activity.getStreamOwner());
       identityStorage.updateProfileActivityId(spaceIdentity, newActivityId, Profile.AttachedActivityType.SPACE);
-      LOG.info(String.format("Migration the space activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), newActivityId));
+      LOG.info("Migrate the profile activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), newActivityId);
     }
   }
 }

--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/utils/IdentityUtil.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/updater/utils/IdentityUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2003-2015 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.exoplatform.social.core.jpa.updater.utils;
+
+
+import org.chromattic.ext.format.BaseEncodingObjectFormatter;
+
+/**
+ * Created by The eXo Platform SAS
+ * Author : eXoPlatform
+ * exo@exoplatform.com
+ * Oct 17, 2016
+ */
+public class IdentityUtil {
+  private static final BaseEncodingObjectFormatter formatter = new BaseEncodingObjectFormatter();
+
+  public static String getIdentityName(String nodeName) {
+    String name = nodeName.replace("soc:", "");
+
+    return formatter.decodeNodeName(null, name);
+  }
+}

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/concurrency/AsynMigrateActivitiesTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/concurrency/AsynMigrateActivitiesTest.java
@@ -38,9 +38,9 @@ public class AsynMigrateActivitiesTest extends AbstractAsynMigrationTest {
     end();
     begin();
     // create jcr data
-    LOG.info("Create connection for root,john,mary and demo");
+    LOG.info("Create connection for root,john.test,mary and demo");
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
 
@@ -126,7 +126,7 @@ public class AsynMigrateActivitiesTest extends AbstractAsynMigrationTest {
     begin();
 
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
 

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/concurrency/MigrationTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/concurrency/MigrationTest.java
@@ -176,7 +176,7 @@ public class MigrationTest extends BaseCoreTest {
 
   public void testMigrateActivityWithMention() throws Exception {
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
     johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
 

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerMysqlTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/ActivityManagerMysqlTest.java
@@ -1319,7 +1319,7 @@ public class ActivityManagerMysqlTest extends AbstractCoreTest {
     assertEquals(0, demoActivityFeed.load(0, 10).length);
     
     ExoSocialActivity comment = new ExoSocialActivityImpl();
-    comment.setTitle("mary mention @demo @john");
+    comment.setTitle("mary mention @demo @john.test");
     comment.setUserId(maryIdentity.getId());
     activityManager.saveComment(activity, comment);
     
@@ -1440,8 +1440,8 @@ public class ActivityManagerMysqlTest extends AbstractCoreTest {
       space.setPriority(Space.INTERMEDIATE_PRIORITY);
       space.setGroupId(SpaceUtils.SPACE_GROUP + "/" + space.getPrettyName());
       space.setUrl(space.getPrettyName());
-      String[] managers = new String[] { "demo", "john" };
-      String[] members = new String[] { "raul", "ghost", "demo", "john" };
+      String[] managers = new String[] { "demo", "john.test" };
+      String[] members = new String[] { "raul", "ghost", "demo", "john.test" };
       String[] invitedUsers = new String[] { "mary", "paul"};
       String[] pendingUsers = new String[] { "jame"};
       space.setInvitedUsers(invitedUsers);

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSActivityStorageImplTest.java
@@ -568,7 +568,7 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
   @MaxQueryNumber(1281)
   public void testMentionersAndCommenters() throws Exception {
     ExoSocialActivity activity = createActivity(1);
-    activity.setTitle("hello @demo @john");
+    activity.setTitle("hello @demo @john.test");
     activityStorage.saveActivity(rootIdentity, activity);
     tearDownActivityList.add(activity);
     
@@ -649,7 +649,7 @@ public class RDBMSActivityStorageImplTest extends AbstractCoreTest {
     activity.setBody("Body of "+ activity.getTitle());
     activity.setBodyId("BodyId of "+ activity.getTitle());
     activity.setLikeIdentityIds(new String[]{"demo", "mary"});
-    activity.setMentionedIds(new String[]{"demo", "john"});
+    activity.setMentionedIds(new String[]{"demo", "john.test"});
     activity.setCommentedIds(new String[]{});
     activity.setReplyToId(new String[]{});
     activity.setAppId("AppID");

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSRelationshipManagerTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/RDBMSRelationshipManagerTest.java
@@ -1100,7 +1100,7 @@ public class RDBMSRelationshipManagerTest extends AbstractCoreTest {
   public void testGetManyRelationshipsByIdentityId() throws Exception {
     String providerId = OrganizationIdentityProvider.NAME;
 
-    Identity sender = identityManager.getOrCreateIdentity(providerId,"john");
+    Identity sender = identityManager.getOrCreateIdentity(providerId,"john.test");
     identityManager.saveIdentity(sender);
     assertNotNull(sender.getId());
 

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/dao/StreamItemDAOTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/dao/StreamItemDAOTest.java
@@ -341,7 +341,7 @@ public class StreamItemDAOTest extends BaseCoreTest {
     activity.setBody("Body of " + activity.getTitle());
     activity.setBodyId("BodyId of " + activity.getTitle());
     activity.setLikeIdentityIds(new String[] { "demo", "mary" });
-    activity.setMentionedIds(new String[] { "demo", "john" });
+    activity.setMentionedIds(new String[] { "demo", "john.test" });
     activity.setCommentedIds(new String[] {});
     activity.setReplyToId(new String[] {});
     activity.setAppId("AppID");

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/listener/ExampleActivityUpdaterListener.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/storage/listener/ExampleActivityUpdaterListener.java
@@ -30,9 +30,9 @@ public class ExampleActivityUpdaterListener extends Listener<ExoSocialActivity, 
   public void onEvent(Event<ExoSocialActivity, String> event) throws Exception {
     ExoSocialActivity activity = event.getSource();
     if (activity.isComment()) {
-      LOG.info(String.format("Migration the comment '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), event.getData()));
+      LOG.info("Migration of comment title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), event.getData());
     } else {
-      LOG.info(String.format("Migration the activity '%s' with old id's %s and new id's %s", activity.getTitle(), activity.getId(), event.getData()));
+      LOG.info("Migration of activity title='{}' old_id={} new_id={}", activity.getTitle(), activity.getId(), event.getData());
     }
   }
 }

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/test/AbstractCoreTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/test/AbstractCoreTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractCoreTest extends BaseExoTestCase {
     identityStorage = getService(RDBMSIdentityStorageImpl.class);
     //
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
   }

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/test/BaseCoreTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/test/BaseCoreTest.java
@@ -116,7 +116,7 @@ public abstract class BaseCoreTest extends BaseExoTestCase {
     entityManagerService = getService(EntityManagerService.class);
     //
     rootIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "root", false);
-    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john", false);
+    johnIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "john.test", false);
     maryIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "mary", false);
     demoIdentity = identityManager.getOrCreateIdentity(OrganizationIdentityProvider.NAME, "demo", false);
   }

--- a/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/test/IdentityUtilTest.java
+++ b/component/core-jpa/src/test/java/org/exoplatform/social/core/jpa/test/IdentityUtilTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2003-2016 eXo Platform SAS.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+*/
+package org.exoplatform.social.core.jpa.test;
+
+import org.exoplatform.commons.testing.BaseExoTestCase;
+import org.exoplatform.social.core.jpa.updater.utils.IdentityUtil;
+
+public class IdentityUtilTest extends BaseExoTestCase {
+  public void testNameConvertion() {
+    assertEquals("name", IdentityUtil.getIdentityName("soc:name"));
+    assertEquals("test.name", IdentityUtil.getIdentityName("soc:name%02test"));
+  }
+}

--- a/component/core-jpa/src/test/resources/conf/standalone/exo.social.test.portal-configuration.xml
+++ b/component/core-jpa/src/test/resources/conf/standalone/exo.social.test.portal-configuration.xml
@@ -184,7 +184,7 @@
                 </value>
                 <value>
                   <object type="org.exoplatform.services.organization.OrganizationConfig$User">
-                    <field  name="userName"><string>john</string></field>
+                    <field  name="userName"><string>john.test</string></field>
                     <field  name="password"><string>gtn</string></field>
                     <field  name="firstName"><string>John</string></field>
                     <field  name="lastName"><string>Anthony</string></field>


### PR DESCRIPTION
- Use the node name instead of the remote_id for identity migration
  - Use Chromattic BaseEncodingObjectFormatter to eventually decode special characters like '.'
- refact some logs to help diagnosis

This PR is a copy of https://github.com/exo-addons/social-rdbms/pull/13 in the social project
