### PR TITLE
PLF-6937 Unkown error after click Share on responsive form

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UIActivity.js
@@ -369,7 +369,8 @@ var UIActivity = {
         });
         composer.find('.button-group').find('.btn-submit').prop('disabled', true);
         composer.find('.share-buttons-top').find('.btn-submit').off('click').click(function() {
-          parent.find('#ShareButton').trigger('click');
+          parent.find('#ShareButton').trigger('onclick');
+          hideComposer($(this));
         });
         composer.find('#ShareButton').off('click').click(function() {
           hideComposer($(this));


### PR DESCRIPTION
We trigger "onclick" instead of "click" on #ShareButton because when we trigger "click", the jquery listener (it clean data in ckeditor/textarea) will be executed before inline onclick. That's why the "unknow error" was shown.