### PR TITLE
PLF-6936 When 2 links are displayed in the microblog the second one is not clickable

### DIFF
--- a/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/URLConverterFilterPlugin.java
+++ b/component/common/src/main/java/org/exoplatform/social/common/xmlprocessor/filters/URLConverterFilterPlugin.java
@@ -130,7 +130,8 @@ public class URLConverterFilterPlugin extends BaseXMLFilterPlugin {
       if(!currentChildNode.get(i).getTitle().equals("a")){
         int insertedCount = nodeFilter(currentChildNode.get(i));
         if( insertedCount > 0){
-          i = i + insertedCount;
+          // We have to reduce 1 because the original node was removed in #convertNode after insert the replacement
+          i = i + insertedCount - 1;
         }
       }
     }
@@ -155,8 +156,8 @@ public class URLConverterFilterPlugin extends BaseXMLFilterPlugin {
         int start = m.start();
         int end = m.end();
         
-        if((start == 0 || content.charAt(start-1) == ' ') &&
-            (end == content.length() || content.charAt(end) == ' ')){
+        if((start == 0 || Character.isWhitespace(content.charAt(start-1))) &&
+            (end == content.length() || Character.isWhitespace(content.charAt(end)))){
           if(!HAVE_PROTOCOL_PREFIX.matcher(url).matches()){
             url = DEFAULT_PROTOCOL + url;
           }

--- a/component/common/src/test/java/org/exoplatform/social/common/xmlprocessor/filters/URLConverterFilterPluginTest.java
+++ b/component/common/src/test/java/org/exoplatform/social/common/xmlprocessor/filters/URLConverterFilterPluginTest.java
@@ -127,4 +127,15 @@ public class URLConverterFilterPluginTest extends TestCase {
         urlConverterFilter.doFilter("http://abc.com:80/abc.jsp?a=1&b=2"));
   }
 
+  public void testURLConverterFilterPluginWithMultiLine() {
+    Filter urlConverterFilter = new URLConverterFilterPlugin(0);
+    assertEquals("demo <a href=\"http://google.com\" target=\"_blank\"" +
+            ">http://google.com</a> test <br />\t\n<a href=\"http://google.com\" target=\"_blank\">http://google.com</a>", urlConverterFilter.doFilter("demo http://google.com test <br />\t\nhttp://google.com"));
+
+    assertEquals("demo <a href=\"http://google.com\" target=\"_blank\"" +
+            ">http://google.com</a> test <br />\t\n <a href=\"http://google.com\" target=\"_blank\">http://google.com</a>", urlConverterFilter.doFilter("demo http://google.com test <br />\t\n http://google.com"));
+
+    assertEquals("demo <a href=\"http://google.com\" target=\"_blank\"" +
+            ">http://google.com</a> test\t\n<br />\t\n<a href=\"http://google.com\" target=\"_blank\">http://google.com</a>\n\t", urlConverterFilter.doFilter("demo http://google.com test\t\n<br />\t\nhttp://google.com\n\t"));
+  }
 }


### PR DESCRIPTION
- Correct the child index after insert some replacement node when process dom (to insert link tag)
- User Character.isWhitespace() method instead of compare with space character directly (to cover the case character is \t, \n,...)