### PR TITLE
PLF-6967 Cant comment or like activity when displayed in the single activity viewer page

### DIFF
--- a/webapp/portlet/src/main/webapp/groovy/social/portlet/UIUserActivityStreamPortlet.gtmpl
+++ b/webapp/portlet/src/main/webapp/groovy/social/portlet/UIUserActivityStreamPortlet.gtmpl
@@ -57,7 +57,7 @@
 	    requireJs.addScripts("activity.setPageTitle('"+ activityTitle +"');");
 	    return;
     }
-    requireJs.addScripts("activity.setPageTitle(window.encodeURIComponent(\""+ activityTitle.replace("\"", "\\42") +"\").replace(/'/, '%27'));");
+    requireJs.addScripts("activity.setPageTitle(window.encodeURIComponent(\""+ activityTitle.replace("\"", "\\42").replace("\n", "").replace("\r", "") +"\").replace(/'/, '%27'));");
   }
   
 %>


### PR DESCRIPTION
The bug is because when we use ckeditor for microblog, it's possible to have new line character (\n\r) in the activity title. And it raise the javascript syntax error when view activity detail

Solution: Remove the new-line character (\n\r) in activity title when set that value as page title.