### PR TITLE
SOC-5596 [Regression][Social-Space] Error when add application to space

### DIFF
--- a/component/webui/src/main/java/org/exoplatform/social/webui/space/UISpaceSetting.java
+++ b/component/webui/src/main/java/org/exoplatform/social/webui/space/UISpaceSetting.java
@@ -119,7 +119,7 @@ public class UISpaceSetting extends UIContainer {
     uiSpaceNavigation.reloadTreeData();
     UISpaceSetting uiSpaceSetting = (UISpaceSetting)getChild(UITabPane.class).getParent();
     uiSpaceNavigation.setSpace(uiSpaceSetting.getSpace());
-    pContext.addUIComponentToUpdateByAjax(uiSpaceNavigation);
+    pContext.addUIComponentToUpdateByAjax(uiSpaceNavigation.getParent());
   }
 
   /**


### PR DESCRIPTION
after we implement the lazy load for ui-tab, the tab content only be loaded when it's selected. So sometime the component UISpaceNavigationManagement is not rendered, so the update on it after add the application will be failed.

Solution to fix: Do update on its parent. It will care both case UISpaceNavigationManagement is rendered or not.