### PR TITLE
PLF-7756 : do not use wildcard characters in search

### DIFF
--- a/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/search/PeopleElasticUnifiedSearchServiceConnector.java
+++ b/component/core-jpa/src/main/java/org/exoplatform/social/core/jpa/search/PeopleElasticUnifiedSearchServiceConnector.java
@@ -41,7 +41,6 @@ import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.identity.model.Profile;
 import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.service.LinkProvider;
-import org.exoplatform.social.core.storage.impl.StorageUtils;
 
 public class PeopleElasticUnifiedSearchServiceConnector extends ElasticSearchServiceConnector {
 
@@ -80,13 +79,7 @@ public class PeopleElasticUnifiedSearchServiceConnector extends ElasticSearchSer
   }
   
   protected String buildFilteredQuery(String query, Collection<String> sites, List<ElasticSearchFilter> filters, int offset, int limit, String sort, String order) {
-    if(query.contains("~")) {
-      query = query.substring(0, query.lastIndexOf("~"));
-    }
     query = query.trim();
-    if(StringUtils.isNotBlank(query)) {
-      query = StorageUtils.ASTERISK_STR + query + StorageUtils.ASTERISK_STR;
-    }
     StringBuilder esQuery = new StringBuilder();
     esQuery.append("{\n");
     esQuery.append("     \"from\" : " + offset + ", \"size\" : " + limit + ",\n");


### PR DESCRIPTION
Because of the use of wildcard in query field  (for example, when searching "test", the query value was "*test*"), the scores of the results are all set to 1. So this PR removes these wildcards to allow to return more accurate scores.
That being said, no weight (boost) has been defined on profile fields during search, nothing has been specified.