### PR TITLE
SOC-5646 TemplateParamsProcessor error due to a missing despecialisation

### DIFF
--- a/component/core/src/main/java/org/exoplatform/social/core/processor/TemplateParamsProcessor.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/TemplateParamsProcessor.java
@@ -58,7 +58,7 @@ public class TemplateParamsProcessor extends BaseActivityProcessorPlugin {
       String key = matcher.group(1);
       String value = params.get(key);
       if (value == null) {
-        value = "";
+        continue;
       }
       template = template.replace(templateKey, value);
     }

--- a/component/core/src/main/java/org/exoplatform/social/core/processor/TemplateParamsProcessor.java
+++ b/component/core/src/main/java/org/exoplatform/social/core/processor/TemplateParamsProcessor.java
@@ -17,6 +17,8 @@
 package org.exoplatform.social.core.processor;
 
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.services.log.ExoLogger;
@@ -27,6 +29,8 @@ import org.exoplatform.social.core.activity.model.ExoSocialActivity;
 
 public class TemplateParamsProcessor extends BaseActivityProcessorPlugin {
   private static final Log LOG = ExoLogger.getLogger(TemplateParamsProcessor.class);
+  private static final Pattern PARAMETER_PATTERN = Pattern.compile("\\$\\{([^}]*)}");
+
   public TemplateParamsProcessor(InitParams params) {
     super(params);
   }
@@ -46,18 +50,16 @@ public class TemplateParamsProcessor extends BaseActivityProcessorPlugin {
       return template;
     }
     
-    int start = 0;
-    int open;
-    int close;
-    while ((open = template.indexOf("${", start)) != -1){
-      start = close = template.indexOf("}");
-      if (close == -1) {
-        throw new Exception("Template is invalid. [Do not contain '}']");
-      }
-
-      String key = template.substring(open + 2, close);
+    Matcher matcher = PARAMETER_PATTERN.matcher(template);
+    int index = 0;
+    while (matcher.find(index)) {
+      index = matcher.end();
+      String templateKey = matcher.group();
+      String key = matcher.group(1);
       String value = params.get(key);
-      String templateKey = "${"+key+"}";
+      if (value == null) {
+        value = "";
+      }
       template = template.replace(templateKey, value);
     }
 

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/TemplateParamsProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/TemplateParamsProcessorTest.java
@@ -57,6 +57,26 @@ public class TemplateParamsProcessorTest extends AbstractCoreTest {
     assertEquals(resultString, activity.getTitle());
   }
 
+  public void testProcessSimpleTemplateWithNullParamValue(){
+    ExoSocialActivity activity = new ExoSocialActivityImpl();
+    String nameKey = "ZUN-NAME";
+    String cityKey = "CITY";
+
+    String templateString = "This is ${" + nameKey + "}. City : ${" + cityKey + "}";
+    String resultString = "This is . City : ";
+    activity.setTitle(templateString);
+    HashMap<String, String> params = new HashMap<String, String>();
+    params.put(nameKey, null);
+    params.put(cityKey, null);
+
+    activity.setTemplateParams(params);
+
+    TemplateParamsProcessor processor = (TemplateParamsProcessor) PortalContainer.getComponent(TemplateParamsProcessor.class);
+    processor.processActivity(activity);
+
+    assertEquals(resultString, activity.getTitle());
+  }
+
   public void testProcessComplicatedTemplate() throws Exception {
     ExoSocialActivity activity = new ExoSocialActivityImpl();
     String nameKey = "ZUN-NAME";

--- a/component/core/src/test/java/org/exoplatform/social/core/processor/TemplateParamsProcessorTest.java
+++ b/component/core/src/test/java/org/exoplatform/social/core/processor/TemplateParamsProcessorTest.java
@@ -63,7 +63,6 @@ public class TemplateParamsProcessorTest extends AbstractCoreTest {
     String cityKey = "CITY";
 
     String templateString = "This is ${" + nameKey + "}. City : ${" + cityKey + "}";
-    String resultString = "This is . City : ";
     activity.setTitle(templateString);
     HashMap<String, String> params = new HashMap<String, String>();
     params.put(nameKey, null);
@@ -74,7 +73,7 @@ public class TemplateParamsProcessorTest extends AbstractCoreTest {
     TemplateParamsProcessor processor = (TemplateParamsProcessor) PortalContainer.getComponent(TemplateParamsProcessor.class);
     processor.processActivity(activity);
 
-    assertEquals(resultString, activity.getTitle());
+    assertEquals(templateString, activity.getTitle());
   }
 
   public void testProcessComplicatedTemplate() throws Exception {


### PR DESCRIPTION
This PR improve Template replacement with params and avoid NPE.