### PR TITLE
PLF-7808 : add Filipino language and rename some javascript modules to not have 3-letters at the end, since lang on 3 letters are now allowed

### DIFF
--- a/extension/war/src/main/webapp/groovy/social/webui/space/UISpaceMenu.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/space/UISpaceMenu.gtmpl
@@ -80,13 +80,13 @@ if (banner != null) {
 String moreLabel = _ctx.appRes("${uicomponentId}.label.More").replace("'", "\\47");
 if(uicomponent.hasSettingPermission()) {
 	_ctx.getRequestContext().getJavascriptManager()
-	        .require("SHARED/social-ui-space-nav", "spacenav")
+	        .require("SHARED/social-ui-space-navigation", "spacenav")
 	        .addScripts("spacenav.addEditability('" + uicomponent.id + "','" + moreLabel + "');")
 	        .addScripts("spacenav.initBanner('#UIBannerUploader');")
 	        .addScripts("spacenav.initAvatar('#UIBannerAvatarUploader');");
 } else {
     _ctx.getRequestContext().getJavascriptManager()
-            .require("SHARED/social-ui-space-nav", "spacenav")
+            .require("SHARED/social-ui-space-navigation", "spacenav")
             .addScripts("spacenav.addEditability('" + uicomponent.id + "','" + moreLabel + "');");
 }
 

--- a/webapp/juzu-portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/juzu-portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -39,6 +39,7 @@
     <supported-locale>en</supported-locale>
     <supported-locale>es-ES</supported-locale>
     <supported-locale>fa</supported-locale>
+    <supported-locale>fil</supported-locale>
     <supported-locale>fr</supported-locale>
     <supported-locale>in</supported-locale>
     <supported-locale>it</supported-locale>

--- a/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/portlet/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -224,7 +224,7 @@
         <module>webui</module>
       </depends>
       <depends>
-        <module>social-ui-space-nav</module>
+        <module>social-ui-space-navigation</module>
       </depends>
     </module>
   </portlet>

--- a/webapp/resources/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapp/resources/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -217,7 +217,7 @@
   </module>
   
   <module>
-    <name>social-ui-space-nav</name>
+    <name>social-ui-space-navigation</name>
       <as>socialUiSpaceNav</as>
     <script>
        <path>/javascript/eXo/social/webui/UISpaceNavigation.js</path>

--- a/webapp/resources/src/test/resources/WEB-INF/gatein-resources.xml
+++ b/webapp/resources/src/test/resources/WEB-INF/gatein-resources.xml
@@ -164,7 +164,7 @@
   </module>
   
   <module>
-    <name>social-ui-space-nav</name>
+    <name>social-ui-space-navigation</name>
     <script>
        <path>/javascript/eXo/social/webui/UISpaceNavigation.js</path>
     </script>


### PR DESCRIPTION
The lang parameter in routes of scripts can now be 2 or 3 letters, so it fails when the scripts ends with a 3-letters part (wcm-webui-ext for example). This PR changes these cases to have more than 3 letters at the end.