### PR TITLE
fix/SOC-6186: Send notification of reacted activities to activity post likers

### DIFF
--- a/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/Utils.java
@@ -16,10 +16,7 @@
  */
 package org.exoplatform.social.notification;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -110,7 +107,7 @@ public class Utils {
     return (id != null);
   }
   
-  public static void sendToCommeters(Set<String> receivers, String[] commenters, String poster) {
+  public static void sendToCommeters  (Set<String> receivers, String[] commenters, String poster) {
     receivers.addAll(getDestinataires(commenters, poster));
   }
   
@@ -144,7 +141,10 @@ public class Utils {
       receivers.add(activityPosterRemoteId);
     }
   }
-  
+
+  public static void sendToActivityLiker(Set<String> receivers, String[] activityLikerIds) {
+    Arrays.stream(activityLikerIds).forEach(activitylikerid -> receivers.add(Utils.getUserId(activitylikerid)));
+  }
   public static void sendToMentioners(Set<String> receivers, String[] mentioners, String poster) {
     receivers.addAll(getDestinataires(mentioners, poster));
   }

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/ActivityCommentPlugin.java
@@ -59,6 +59,7 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
         Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
         Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
         Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+        Utils.sendToActivityLiker(receivers, activity.getLikeIdentityIds());
         receivers.remove(parentCommentUserPosterId);
       }
     } else {
@@ -66,6 +67,7 @@ public class ActivityCommentPlugin extends BaseNotificationPlugin {
       Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
       Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
       Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+      Utils.sendToActivityLiker(receivers, activity.getLikeIdentityIds());
     }
     //
     return NotificationInfo.instance()

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditActivityPlugin.java
@@ -39,6 +39,7 @@ public class EditActivityPlugin extends BaseNotificationPlugin {
             Utils.sendToCommeters(receivers, activity.getCommentedIds(), activity.getPosterId());
             Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), activity.getPosterId());
             Utils.sendToActivityPoster(receivers, activity.getPosterId(), activity.getPosterId());
+            Utils.sendToActivityLiker(receivers, activity.getLikeIdentityIds());
 
         //
         return NotificationInfo.instance()

--- a/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditCommentPlugin.java
+++ b/component/notification/src/main/java/org/exoplatform/social/notification/plugin/EditCommentPlugin.java
@@ -41,6 +41,7 @@ public class EditCommentPlugin  extends BaseNotificationPlugin {
                 Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
                 Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
                 Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+                Utils.sendToActivityLiker(receivers, activity.getLikeIdentityIds());
                 receivers.remove(parentCommentUserPosterId);
             }
         } else {
@@ -48,6 +49,7 @@ public class EditCommentPlugin  extends BaseNotificationPlugin {
             Utils.sendToCommeters(receivers, activity.getCommentedIds(), comment.getPosterId());
             Utils.sendToStreamOwner(receivers, activity.getStreamOwner(), comment.getPosterId());
             Utils.sendToActivityPoster(receivers, activity.getPosterId(), comment.getPosterId());
+            Utils.sendToActivityLiker(receivers, activity.getLikeIdentityIds());
         }
         //
         return NotificationInfo.instance()

--- a/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/LikeMailBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/channel/template/LikeMailBuilderTest.java
@@ -79,7 +79,7 @@ public class LikeMailBuilderTest extends AbstractPluginTest {
     //STEP 2 like activity
     activityManager.saveLike(activity, demoIdentity);
 
-    assertMadeMailDigestNotifications(1);
+    assertMadeMailDigestNotifications(2);
     List<NotificationInfo> list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 1);
     NotificationInfo likeNotification = list.get(0);
     
@@ -98,7 +98,7 @@ public class LikeMailBuilderTest extends AbstractPluginTest {
     activityManager.saveLike(activity, demoIdentity);
     activityManager.saveLike(activity, johnIdentity);
     //
-    assertMadeMailDigestNotifications(3);
+    assertMadeMailDigestNotifications(9);
     List<NotificationInfo> list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 3);
     
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
@@ -126,7 +126,7 @@ public class LikeMailBuilderTest extends AbstractPluginTest {
     
     activityManager.saveLike(activity, maryIdentity);
     
-    assertMadeMailDigestNotifications(1);
+    assertMadeMailDigestNotifications(2);
     List<NotificationInfo> list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 1);
     NotificationInfo likeNotification = list.get(0);
     
@@ -152,7 +152,7 @@ public class LikeMailBuilderTest extends AbstractPluginTest {
     activityManager.saveLike(activity, demoIdentity);
     activityManager.saveLike(activity, johnIdentity);
 
-    assertMadeMailDigestNotifications(2);
+    assertMadeMailDigestNotifications(5);
     list = assertMadeMailDigestNotifications(rootIdentity.getRemoteId(), 2);
 
     // john unlike

--- a/component/notification/src/test/java/org/exoplatform/social/notification/web/template/LikeWebBuilderTest.java
+++ b/component/notification/src/test/java/org/exoplatform/social/notification/web/template/LikeWebBuilderTest.java
@@ -68,7 +68,7 @@ public class LikeWebBuilderTest extends AbstractPluginTest {
     //STEP 2 like activity
     activityManager.saveLike(activity, demoIdentity);
     
-    assertMadeWebNotifications(1);
+    assertMadeWebNotifications(2);
     List<NotificationInfo> list = assertMadeWebNotifications(rootIdentity.getRemoteId(), 1);
     NotificationInfo likeNotification = list.get(0);
     


### PR DESCRIPTION
When liking a post, we don't receive any notification of reacted activity such as a new comment , reply or editing them. So in order to receive them we need to add the list of likers to the notification receivers.
**Tested on :** platform-5.2.x-SNAPSHOT