### PR TITLE
PLF-8166: initialize sticky banner when document is Ready

### DIFF
--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UISpaceNavigation.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UISpaceNavigation.js
@@ -78,6 +78,7 @@ var UISpaceNavigation = {
 	    var liElements = ul.find('> li');
 	    liElements.addClass('item');
 	    autoMoveApps();
+        UISpaceNavigation.initStickyBanner();
     });
 
     $(window).resize(function(){
@@ -130,7 +131,6 @@ var UISpaceNavigation = {
 	      window.location = href;
 	    }
 	  };
-	  UISpaceNavigation.initStickyBanner();
 	},
 	initNavigation : function(index, moreLabel) {
 	  //

--- a/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UISpaceNavigation.js
+++ b/webapp/resources/src/main/webapp/javascript/eXo/social/webui/UISpaceNavigation.js
@@ -78,7 +78,6 @@ var UISpaceNavigation = {
 	    var liElements = ul.find('> li');
 	    liElements.addClass('item');
 	    autoMoveApps();
-        UISpaceNavigation.initStickyBanner();
     });
 
     $(window).resize(function(){


### PR DESCRIPTION
This issue is caused by a conflict of function execution between autoMoveApps() function and initStickyBanner() which resets the dom so the  $selectedTab variable returns undefined 
The suggested solution is to execute initStickyBanner() on document Ready