### PR TITLE
fix-8334 : Edit mailing notification template for Microsoft outlook a…

### DIFF
--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/ActivityMentionPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/ActivityMentionPlugin.gtmpl
@@ -21,9 +21,18 @@
                                         <p style="margin: 10px 0 5px; color: #333333; font-size:13px;font-family:'HelveticaNeue bold',verdana,arial,tahoma"><%=_ctx.appRes("Notification.label.SayHello")%> <%=_ctx.escapeHTML(FIRSTNAME)%>,</p>
                                         <table border="0" cellpadding="0" cellspacing="0" >
                                             <tr>
-                                                <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff;">
-                                                    <img width="75px" height="75px" style="margin-top: 6px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
-                                                </td>
+                                                    <!--[if mso]>
+                                                        <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
+                                                            <img width="75" height="75" border="1" style="margin-top: 6px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                        </td>
+                                                         <div style="display:none">
+                                                    <![endif]-->
+                                                    <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff;">
+                                                         <img width="75px" height="75px" style="margin-top: 6px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                    </td>
+                                                    <!--[if mso]>
+                                                      </div>
+                                                   <![endif]-->
                                                 <td  valign="top" style="margin-top: 0px;">
                                                     <p style="margin: 0 0 10px 0; line-height: 22px; color: #333333; font-size:13px; font-family:'HelveticaNeue bold',verdana,arial,tahoma">
                                                       <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/ActivityMentionPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/ActivityMentionPlugin.gtmpl
@@ -25,14 +25,10 @@
                                                         <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
                                                             <img width="75" height="75" border="1" style="margin-top: 6px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                         </td>
-                                                         <div style="display:none">
                                                     <![endif]-->
-                                                    <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff;">
+                                                    <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff; mso-hide:all;">
                                                          <img width="75px" height="75px" style="margin-top: 6px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                     </td>
-                                                    <!--[if mso]>
-                                                      </div>
-                                                   <![endif]-->
                                                 <td  valign="top" style="margin-top: 0px;">
                                                     <p style="margin: 0 0 10px 0; line-height: 22px; color: #333333; font-size:13px; font-family:'HelveticaNeue bold',verdana,arial,tahoma">
                                                       <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/NewUserPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/NewUserPlugin.gtmpl
@@ -21,9 +21,18 @@
                                         <p style="margin: 10px 0 5px; color: #333333; line-height: 20px; font-size:13px;"><%=_ctx.appRes("Notification.label.SayHello")%> <%=_ctx.escapeHTML(FIRSTNAME)%>,</p>
                                         <table border="0" cellpadding="0" cellspacing="0" >
                                             <tr>
+                                                 <!--[if mso]>
+                                                     <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
+                                                        <img width="70" height="70" border="1" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                     </td>
+                                                        <div style="display:none">
+                                                 <![endif]-->
                                                  <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff;">
                                                     <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
-                                                </td>
+                                                 </td>
+                                                 <!--[if mso]>
+                                                    </div>
+                                                 <![endif]-->
                                                 <td  valign="top">
                                                     <p style="margin:0 0 12px; color: #333333; font-family:HelveticaNeue,arial,tahoma,serif; font-size:13px; line-height: 20px;">
                                                       <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/NewUserPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/NewUserPlugin.gtmpl
@@ -25,14 +25,10 @@
                                                      <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
                                                         <img width="70" height="70" border="1" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                      </td>
-                                                        <div style="display:none">
                                                  <![endif]-->
-                                                 <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff;">
+                                                 <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff; mso-hide:all;">
                                                     <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                  </td>
-                                                 <!--[if mso]>
-                                                    </div>
-                                                 <![endif]-->
                                                 <td  valign="top">
                                                     <p style="margin:0 0 12px; color: #333333; font-family:HelveticaNeue,arial,tahoma,serif; font-size:13px; line-height: 20px;">
                                                       <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/RelationshipReceivedRequestPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/RelationshipReceivedRequestPlugin.gtmpl
@@ -21,9 +21,19 @@
                                         <p style="margin: 10px 0 5px;font-size:13px; color: #333333; font-family:'HelveticaNeue bold', Arial, sans-serif"><%=_ctx.appRes("Notification.label.SayHello")%> <%=_ctx.escapeHTML(FIRSTNAME)%>,</p>
                                         <table border="0" cellpadding="0" cellspacing="0" bgcolor="#ffffff" style="background: #ffffff;" >
                                             <tr>
-                                                <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff;">
-                                                    <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                <!--[if mso]>
+                                                <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
+                                                    <img width="70" height="70" border="1" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                 </td>
+                                                <div style="display:none">
+                                                <![endif]-->
+                                                <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff;">
+                                                    <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" /
+                                                </td>
+                                                <!--[if mso]>
+                                                </div>
+                                                <![endif]-->
+                                                    <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                 <td  valign="top" bgcolor="#ffffff" style="background: #ffffff;">
                                                     <p style="margin:0 0 10px 0;line-height: 20px; color: #333333; font-size:13px;font-family:'HelveticaNeue bold',Arial,sans-serif">
                                                          <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/RelationshipReceivedRequestPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/RelationshipReceivedRequestPlugin.gtmpl
@@ -25,15 +25,10 @@
                                                 <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
                                                     <img width="70" height="70" border="1" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                 </td>
-                                                <div style="display:none">
                                                 <![endif]-->
-                                                <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff;">
-                                                    <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" /
-                                                </td>
-                                                <!--[if mso]>
-                                                </div>
-                                                <![endif]-->
+                                                <td valign="top" width="90px" bgcolor="#ffffff" style="background: #ffffff; mso-hide:all;">
                                                     <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                </td>
                                                 <td  valign="top" bgcolor="#ffffff" style="background: #ffffff;">
                                                     <p style="margin:0 0 10px 0;line-height: 20px; color: #333333; font-size:13px;font-family:'HelveticaNeue bold',Arial,sans-serif">
                                                          <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/RequestJoinSpacePlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/RequestJoinSpacePlugin.gtmpl
@@ -21,9 +21,18 @@
                                     <p style="margin: 10px 0 5px;font-size:13px; color: #333333; font-family:'HelveticaNeue bold', Arial, sans-serif;"><%=_ctx.appRes("Notification.label.SayHello")%> <%=_ctx.escapeHTML(FIRSTNAME)%>,</p>
                                     <table border="0" cellpadding="0" cellspacing="0" >
                                         <tr>
+                                            <!--[if mso]>
+                                                <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
+                                                     <img width="70" height="70" border="1" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                </td>                                        
+                                            <div style="display:none">
+                                            <![endif]-->
                                             <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff;">
-                                                <img height="70px" width="70px" style="margin-top: 5px; webkit-border-radius: 3px; moz-border-radius: 3px;border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" /
                                             </td>
+                                            <!--[if mso]>
+                                                </div>
+                                            <![endif]-->
                                             <td  valign="top" bgcolor="#ffffff" style="background-color: #ffffff;">
                                                 <p style="margin:0 0 10px; line-height: 20px; color: #333333; font-size:13px; font-family:'HelveticaNeue bold', Arial, sans-serif;">
 	                                                   <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/RequestJoinSpacePlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/RequestJoinSpacePlugin.gtmpl
@@ -24,15 +24,11 @@
                                             <!--[if mso]>
                                                 <td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
                                                      <img width="70" height="70" border="1" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
-                                                </td>                                        
-                                            <div style="display:none">
+                                                </td>
                                             <![endif]-->
-                                            <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff;">
-                                                <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" /
+                                            <td valign="top" width="90px" bgcolor="#ffffff" style="background-color: #ffffff; mso-hide:all;">
+                                                <img width="70px" height="70px" style="margin-top: 5px;border-radius: 4px;border: 1px solid #c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                             </td>
-                                            <!--[if mso]>
-                                                </div>
-                                            <![endif]-->
                                             <td  valign="top" bgcolor="#ffffff" style="background-color: #ffffff;">
                                                 <p style="margin:0 0 10px; line-height: 20px; color: #333333; font-size:13px; font-family:'HelveticaNeue bold', Arial, sans-serif;">
 	                                                   <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
@@ -21,9 +21,18 @@
                                     <p style="margin: 10px 0 5px; font-size: 13px; color: #333333; font-family:'HelveticaNeue bold',arial,tahoma;"><%=_ctx.appRes("Notification.label.SayHello")%> <%=_ctx.escapeHTML(FIRSTNAME)%>,</p>
                                     <table border="0" cellpadding="0" cellspacing="0" >
                                         <tr>
+                                            <!--[if mso]>
+                                                <td valign="top" width="90">
+                                                    <img width="70" height="70" border="1" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                </td>
+                                                <div style="display:none">
+                                            <![endif]-->
                                             <td valign="top" width="90px">
-                                                <img height="70" width="70" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$SPACE_AVATAR" alt="<%=_ctx.escapeHTML(SPACE)%>" />
+                                                <img width="70px" height="70px" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" /
                                             </td>
+                                            <!--[if mso]>
+                                            </div>
+                                            <![endif]-->
                                             <td  valign="top">
                                                 <p style="margin:0 0 12px; color: #333333; line-height: 20px; font-size:13px; font-family: HelveticaNeue,Helvetica,Arial,sans-serif;">
                                                     <%

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
@@ -23,11 +23,11 @@
                                         <tr>
                                             <!--[if mso]>
                                                 <td valign="top" width="90">
-                                                    <img width="70" height="70" border="1" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                    <img width="70" height="70" border="1" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$SPACE_AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                 </td>
                                             <![endif]-->
                                             <td valign="top" width="90px" style="mso-hide:all;">
-                                                <img width="70px" height="70px" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
+                                                <img width="70px" height="70px" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$SPACE_AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                             </td>
                                             <td  valign="top">
                                                 <p style="margin:0 0 12px; color: #333333; line-height: 20px; font-size:13px; font-family: HelveticaNeue,Helvetica,Arial,sans-serif;">

--- a/extension/notification/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
+++ b/extension/notification/src/main/webapp/WEB-INF/notification/templates/SpaceInvitationPlugin.gtmpl
@@ -25,14 +25,10 @@
                                                 <td valign="top" width="90">
                                                     <img width="70" height="70" border="1" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                 </td>
-                                                <div style="display:none">
                                             <![endif]-->
-                                            <td valign="top" width="90px">
-                                                <img width="70px" height="70px" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" /
+                                            <td valign="top" width="90px" style="mso-hide:all;">
+                                                <img width="70px" height="70px" style="margin-top: 5px; -webkit-border-radius: 3px; -moz-border-radius: 3px; border-radius: 3px;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                             </td>
-                                            <!--[if mso]>
-                                            </div>
-                                            <![endif]-->
                                             <td  valign="top">
                                                 <p style="margin:0 0 12px; color: #333333; line-height: 20px; font-size:13px; font-family: HelveticaNeue,Helvetica,Arial,sans-serif;">
                                                     <%


### PR DESCRIPTION
In a customer environment and also on PLF when an email notification with a user avatar is received in an email client  (Microsoft Outlook application), the image size is too bigger than an online
 webmail (Gmail, Outlook...).
In fact, i searched the web and i found that Microsoft Outlook application can't resolve width and height value with px (width: 75px, height: 75px ) as mentioned in our notification templates and this problem can be resolved by using conditional formatting <!--[if mso]>  that allows you to insert an image whose  height and are without ( px ) and It only renders if the client is mso.
`<td valign="top" width="90" bgcolor="#ffffff" style="background-color: #ffffff;">
 <img width="75" height="75" border="1" style="margin-top: 6px;border-radius: 4px;border: 1px solid#c7c7c7;" src="$AVATAR" alt="<%=_ctx.escapeHTML(USER)%>" />
                                                        </td>`
