### PR TITLE
PLF-8345: fix the Redirection problem in the profile name

### DIFF
--- a/extension/war/src/main/webapp/groovy/social/webui/profile/UIRecentActivity.gtmpl
+++ b/extension/war/src/main/webapp/groovy/social/webui/profile/UIRecentActivity.gtmpl
@@ -43,7 +43,7 @@ if(activity == null) {
              <div><a href="javascript:void(0);" onclick="(function(evt){ evt.stopPropagation(); window.open('<%=link%>', '_self');})(event)"><%=activity.getTitle()%></a></div>
        <%  }
          } else {%>
-             <div class="status"><%=activity.getTitle()%></div>
+             <div class="status"><span onclick="event.stopPropagation();"><%=activity.getTitle()%></span></div>
        <%} %>
        </div>
      </div> <!-- #boxContainer-->


### PR DESCRIPTION
fix the Redirection problem by stop the propagation of the event in the parent elements using The **event.stopPropagation()** method.