### PR TITLE
Fix/SOC-6098: Add Message Entry to exist connection request 

### DIFF
--- a/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
+++ b/webapp/portlet/src/main/resources/locale/portlet/Portlets_en.properties
@@ -51,6 +51,8 @@ UIMembersPortlet.label.Confirm=Confirm
 UIMembersPortlet.label.Ignore=Ignore
 UIMembersPortlet.label.RemoveConnection=Remove Connection
 UIMembersPortlet.label.CancelRequest=Cancel Request
+UIMembersPortlet.label.InvitationEstablishedInfo=Invitation was established by someone else.
+
 
 #####################################################################################
 #                           UIEditUserProfileForm                                   #


### PR DESCRIPTION
Add Translate Entry to exist connection invitation message popup inside the space member list.
The same message as [https://github.com/exoplatform/social/blob/cfa81421250e9fcd53c754c2995d855bf20a50b7/component/webui/src/main/resources/locale/social/Webui_en.properties#L374](Link)